### PR TITLE
Align LambdaLayer schema with serverless config schema

### DIFF
--- a/serverless/reference.json
+++ b/serverless/reference.json
@@ -41640,18 +41640,25 @@
       "type": "object"
     },
     "Aws.Layer": {
+      "type": "object",
       "properties": {
         "allowedAccounts": {
+          "type": "array",
           "items": {
             "type": "string"
-          },
-          "type": "array"
+          }
+        },
+        "compatibleArchitectures": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         },
         "compatibleRuntimes": {
+          "type": "array",
           "items": {
             "type": "string"
-          },
-          "type": "array"
+          }
         },
         "description": {
           "type": "string"
@@ -41662,23 +41669,39 @@
         "name": {
           "type": "string"
         },
+        "package": {
+          "type": "object",
+          "properties": {
+            "artifact": {
+              "type": "string"
+            },
+            "exclude": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "include": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "patterns": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
         "path": {
           "type": "string"
         },
         "retain": {
           "type": "boolean"
         }
-      },
-      "oneOf": [
-        {
-          "type": "object",
-          "minimum": 1
-        },
-        {
-          "type": "string",
-          "minimum": 1
-        }
-      ]
+      }
     },
     "Aws.Layers": {
       "additionalProperties": {


### PR DESCRIPTION
Taking the config schema defined in serverless framework as a starting point, this fixes the LambdaLayer schema to prevent Incorrect Type errors when setting a package definition.

Fixes #4

See https://github.com/serverless/serverless/blob/v3.7.1/lib/plugins/aws/provider.js#L1304-L1350
