### PR TITLE
fix: :bug: updated schedule type to be one of string or array of string

### DIFF
--- a/serverless/reference.json
+++ b/serverless/reference.json
@@ -42318,7 +42318,17 @@
           "type": "string"
         },
         "rate": {
-          "type": "string"
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
         }
       },
       "type": "object"


### PR DESCRIPTION
This is the beginning of long term support plan for serverless framework support.
Will be providing further updates soon.