### PR TITLE
added missing event information for cloudwatch events

### DIFF
--- a/serverless/reference.json
+++ b/serverless/reference.json
@@ -41118,7 +41118,14 @@
           "type": "boolean"
         },
         "event": {
-          "type": "string"
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "$ref": "#/definitions/Aws.CloudwatchEvent.InternalEvent"
+            }
+          ]
         },
         "input": {
           "$ref": "#/definitions/Aws.Input"
@@ -41134,6 +41141,64 @@
         }
       },
       "type": "object"
+    },
+    "Aws.CloudwatchEvent.InternalEvent": {
+      "properties": {
+        "source": {
+          "oneOf": [
+            {
+              "type":"string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "detail-type": {
+          "oneOf": [
+            {
+              "type":"string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "detail": {
+          "type": "object"
+        },
+        "region": {
+          "type": "string"
+        },
+        "resources": {
+          "type": "array",
+          "description": "This is an array of arns",
+          "items": {
+            "type": "string"
+          }
+        },
+        "version": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "time": {
+          "type": "string"
+        },
+        "account": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "source"
+      ]
     },
     "Aws.CloudwatchLog": {
       "properties": {


### PR DESCRIPTION
Question of stack overflow that ended up in my feed.
https://stackoverflow.com/questions/71124403/incorrect-schema-for-yaml-file-using-serverless-framework-configuration-expect

Have also created the PR on definitely types for serverless [here](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/59966#issuecomment-1102975854). Please give it a +1 so it gets merged as well.