### PR TITLE
fix: add missing EventBusName property for AWS_Events_Rule

### DIFF
--- a/serverless/reference.json
+++ b/serverless/reference.json
@@ -10529,6 +10529,10 @@
               "description": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-events-rule.html#cfn-events-rule-description",
               "$ref": "#/definitions/Expression"
             },
+            "EventBusName": {
+              "description": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-events-rule.html#cfn-events-rule-eventbusname",
+              "$ref": "#/definitions/Expression"
+            },
             "EventPattern": {
               "description": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-events-rule.html#cfn-events-rule-eventpattern",
               "anyOf": [


### PR DESCRIPTION
Adds missing property `EventBusName` property to `AWS_Events_Rule`, as defined in the AWS CloudFormation docs: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-events-rule.html#cfn-events-rule-eventbusname

closes #19 