### PR TITLE
feat: :sparkles: added new nodejs16.x runtime to enum of supported runtimes

### DIFF
--- a/serverless/reference.json
+++ b/serverless/reference.json
@@ -37868,7 +37868,7 @@
           "type": "string"
         },
         "runtime": {
-          "type": "string"
+          "$ref": "#/definitions/Aws.Runtime"
         },
         "tags": {
           "$ref": "#/definitions/Aws.Tags"
@@ -40209,6 +40209,26 @@
       },
       "type": "object"
     },
+    "Aws.Runtime": {
+      "type": "string",
+      "enum": [
+        "nodejs16.x",
+        "nodejs14.x",
+        "nodejs12.x",
+        "python3.9",
+        "python3.8",
+        "python3.7",
+        "python3.6",
+        "ruby2.7",
+        "java11",
+        "java8.al2",
+        "java8",
+        "go1.x",
+        "dotnet6",
+        "dotnetcore3.1"
+      ],
+      "description": "https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html"
+    },
     "Aws.Provider": {
       "properties": {
         "alb": {
@@ -40360,23 +40380,7 @@
           "$ref": "#/definitions/Aws.RollbackConfiguration"
         },
         "runtime": {
-          "type": "string",
-          "enum": [
-            "nodejs14.x",
-            "nodejs12.x",
-            "python3.9",
-            "python3.8",
-            "python3.7",
-            "python3.6",
-            "ruby2.7",
-            "java11",
-            "java8.al2",
-            "java8",
-            "go1.x",
-            "dotnet6",
-            "dotnetcore3.1"
-          ],
-          "description": "https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html"
+          "$ref": "#/definitions/Aws.Runtime"
         },
         "stackName": {
           "type": "string"


### PR DESCRIPTION
Also started using this enum for functions.runtime which was previously just string
Solves #22 