### PR TITLE
fix: support array of resources, update AppSync definitions

### DIFF
--- a/serverless/reference.json
+++ b/serverless/reference.json
@@ -40924,7 +40924,17 @@
       "$ref": "#/definitions/Aws.Provider"
     },
     "resources": {
-      "$ref": "#/definitions/Aws.Resources"
+      "oneOf": [
+        {
+          "$ref": "#/definitions/Aws.Resources"
+        },
+        {
+          "items": {
+            "$ref": "#/definitions/Aws.Resources"
+          },
+          "type": "array"
+        }
+      ]
     },
     "service": {
       "anyOf": [

--- a/serverless/reference.json
+++ b/serverless/reference.json
@@ -2290,14 +2290,16 @@
           "type": "object",
           "properties": {
             "CertificateArn": {
-              "type": "string",
-              "description": "The Amazon Resource Name (ARN) of the certificate. This will be an AWS Certificate Manager certificate."
+              "description": "The Amazon Resource Name (ARN) of the certificate. This will be an AWS Certificate Manager certificate.",
+              "$ref": "#/definitions/Expression"
             },
             "Description": {
-              "type": "string"
+              "description": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-domainname.html#cfn-appsync-domainname-description",
+              "$ref": "#/definitions/Expression"
             },
             "DomainName": {
-              "type": "string"
+              "description": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-domainname.html#cfn-appsync-domainname-domainname",
+              "$ref": "#/definitions/Expression"
             }
           },
           "required": ["CertificateArn", "DomainName"]
@@ -2317,10 +2319,12 @@
           "type": "object",
           "properties": {
             "ApiId": {
-              "type": "string"
+              "description": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-domainnameapiassociation.html#cfn-appsync-domainnameapiassociation-apiid",
+              "$ref": "#/definitions/Expression"
             },
             "DomainName": {
-              "type": "string"
+              "description": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-domainnameapiassociation.html#cfn-appsync-domainnameapiassociation-domainname",
+              "$ref": "#/definitions/Expression"
             }
           },
           "required": ["ApiId", "DomainName"]


### PR DESCRIPTION
According to [this comment](https://github.com/serverless/serverless/issues/2828#issuecomment-333305670), it's possible to define resources as an array:

```yaml
resources:
  - ${file(res1.yml)}
  - ${file(res2.yml)}
  - Resources:
      Foo:
        Type: AWS::S3::Bucket
        Properties:
          BucketName: foo
  - Resources:
      Bar:
        Type: AWS::S3::Bucket
        Properties:
          BucketName: bar
```

Additionally, this PR fixes AppSync definitions to use Expression instead of string to allow intrinsic functions.