### PR TITLE
fix: proper AWS HttpRequestValidation for path

### DIFF
--- a/serverless/reference.json
+++ b/serverless/reference.json
@@ -39910,7 +39910,21 @@
           "type": "string",
           "enum": [
             "ANY /",
-            "ANY {proxy+}"
+            "GET /",
+            "POST /",
+            "PUT /",
+            "PATCH /",
+            "OPTIONS /",
+            "HEAD /",
+            "DELETE /",
+            "ANY /{proxy+}",
+            "GET /{proxy+}",
+            "POST /{proxy+}",
+            "PUT /{proxy+}",
+            "PATCH /{proxy+}",
+            "OPTIONS /{proxy+}",
+            "HEAD /{proxy+}",
+            "DELETE /{proxy+}"
           ]
         }
       ]


### PR DESCRIPTION
TLDR: `"ANY {proxy+}"` is invalid, replaced with `"ANY /{proxy+}"`

Based on errors from serverless framework I improved JSON schema for HTTP request path.

```
Warning: Invalid configuration encountered
  at 'functions.api.events.1.http': value 'ANY {proxy+}' does not satisfy pattern /^(?:\*|(GET|POST|PUT|PATCH|OPTIONS|HEAD|DELETE|ANY) (\/\S*))$/i
```

It is still not complete (no support for `ANY /any-path-here-but-not-proxy`) but it at least aligns with what serverless framework expects.