### PR TITLE
fix: 🐛 update pattern for aws file path to allow property references

### DIFF
--- a/serverless/reference.json
+++ b/serverless/reference.json
@@ -40955,7 +40955,7 @@
     {
       "type": "string",
       "minimum": 1,
-      "pattern": "\\$\\{file\\(.+\\.(yml|yaml)\\)\\}"
+      "pattern": "\\$\\{file\\(.+\\.(yml|yaml)\\)(:[A-Za-z])?\\}"
     },
     "Aws.RestApiLogs": {
       "properties": {


### PR DESCRIPTION
# Overview

At present, the path pattern allows for file references like `${file(src/example.yml)}`, but does not allow for nested property reference such as `${file(src/example.yml):foo}` where `foo` is a property within that `*.yml` file. These are valid for serverless configurations but are not "valid" according to this schema.