### PR TITLE
Allow strings in AWS resources

### DIFF
--- a/serverless/reference.json
+++ b/serverless/reference.json
@@ -40947,6 +40947,10 @@
           "minimum": 1
         },
         {
+          "type": "string",
+          "minimum": 1
+        },
+        {
           "$ref": "#/definitions/Serverless.FilePath"
         }
       ]

--- a/serverless/reference.json
+++ b/serverless/reference.json
@@ -40955,7 +40955,7 @@
         }
       ]
     },
-    "Serverless.FilePath": 
+    "Serverless.FilePath":
     {
       "type": "string",
       "minimum": 1,


### PR DESCRIPTION
This pull request allows strings in AWS resources, this enables the following to appear as valid:
```
resources:
  - ${file(./${self:provider.stage}-dynamodb.yaml), ''}
```

A use case is that you want a certain file to be used only for one stage but not another, adding the `''` acts like a noop and prevents an error if the file doesn't exist for a certain stage.

At the moment the following appears as valid but causes a `Variable syntax error at "resources.0"`:
```
resources:
  - ${file(./${self:provider.stage}-dynamodb.yaml), '', file(.yml)}
```