### PR TITLE
Replace and remove invalid keywords

### DIFF
--- a/serverless/reference.json
+++ b/serverless/reference.json
@@ -38635,8 +38635,7 @@
       },
       "oneOf": [
         {
-          "type": "object",
-          "minimum": 1
+          "type": "object"
         },
         {
           "type": "string",
@@ -38660,7 +38659,6 @@
     },
     "Aws.StateMachine": {
       "type": "object",
-      "minimum": 1,
       "additionalProperties": {
         "type": "object",
         "properties": {
@@ -38775,8 +38773,7 @@
               {
                 "$ref": "#/definitions/Aws.StateMachine.States.Map"
               }
-            ],
-            "minimum": 1
+            ]
           }
         },
         "Version": {
@@ -40550,8 +40547,7 @@
       },
       "oneOf": [
         {
-          "type": "object",
-          "minimum": 1
+          "type": "object"
         },
         {
           "type": "string",
@@ -40831,8 +40827,7 @@
       },
       "oneOf": [
         {
-          "type": "object",
-          "minimum": 1
+          "type": "object"
         },
         {
           "type": "string",
@@ -40943,8 +40938,7 @@
       },
       "oneOf": [
         {
-          "type": "object",
-          "minimum": 1
+          "type": "object"
         },
         {
           "$ref": "#/definitions/Serverless.FilePath"

--- a/serverless/reference.json
+++ b/serverless/reference.json
@@ -38640,7 +38640,7 @@
         },
         {
           "type": "string",
-          "minimum": 1
+          "minLength": 1
         },
         {
           "type": "array",
@@ -40555,7 +40555,7 @@
         },
         {
           "type": "string",
-          "minimum": 1
+          "minLength": 1
         }
       ]
     },
@@ -40836,7 +40836,7 @@
         },
         {
           "type": "string",
-          "minimum": 1
+          "minLength": 1
         }
       ]
     },
@@ -40954,7 +40954,7 @@
     "Serverless.FilePath": 
     {
       "type": "string",
-      "minimum": 1,
+      "minLength": 1,
       "pattern": "\\$\\{file\\(.+\\.(yml|yaml)\\)(:[A-Za-z]+)?(\\s*?,\\s*?(\"\"|''))?\\}"
     },
     "Aws.RestApiLogs": {


### PR DESCRIPTION
This pull request replaces the `minimum` keyword with `minLength` for the [string](https://json-schema.org/understanding-json-schema/reference/string.html) type and removes `minimum` for the [object](https://json-schema.org/understanding-json-schema/reference/object.html) type.