### PR TITLE
Allow HTTP API strings

### DIFF
--- a/serverless/reference.json
+++ b/serverless/reference.json
@@ -39967,25 +39967,33 @@
       "type": "object"
     },
     "Aws.HttpApiEvent": {
-      "properties": {
-        "authorizer": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/Aws.NamedHttpApiEventAuthorizer"
+      "oneOf": [
+        {
+          "properties": {
+            "authorizer": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/Aws.NamedHttpApiEventAuthorizer"
+                },
+                {
+                  "$ref": "#/definitions/Aws.IdRefHttpApiEventAuthorizer"
+                }
+              ]
             },
-            {
-              "$ref": "#/definitions/Aws.IdRefHttpApiEventAuthorizer"
+            "method": {
+              "type": "string"
+            },
+            "path": {
+              "type": "string"
             }
-          ]
+          },
+          "type": "object"
         },
-        "method": {
-          "type": "string"
-        },
-        "path": {
-          "type": "string"
+        {
+          "type": "string",
+          "minLength": 1
         }
-      },
-      "type": "object"
+      ]
     },
     "Aws.HttpApiLogs": {
       "properties": {


### PR DESCRIPTION
This pull request allows strings for [HTTP APIs](https://www.serverless.com/blog/aws-http-api-support/).