### PR TITLE
Allow strings for S3

### DIFF
--- a/serverless/reference.json
+++ b/serverless/reference.json
@@ -41026,7 +41026,15 @@
           "type": "array"
         }
       },
-      "type": "object"
+      "oneOf": [
+        {
+          "type": "object"
+        },
+        {
+          "type": "string",
+          "minLength": 1
+        }
+      ]
     },
     "Aws.S3Rule": {
       "properties": {


### PR DESCRIPTION
This pull request allows strings for [S3](https://www.serverless.com/framework/docs/providers/aws/events/s3) buckets.