### PR TITLE
Improve resource default value pattern

### DIFF
--- a/serverless/reference.json
+++ b/serverless/reference.json
@@ -40949,7 +40949,7 @@
     {
       "type": "string",
       "minLength": 1,
-      "pattern": "\\$\\{file\\(.+\\.(yml|yaml)\\)(:[A-Za-z]+)?(\\s*?,\\s*?(\"\"|''))?\\}"
+      "pattern": "\\$\\{file\\(.+\\.(yml|yaml)\\)(:[A-Za-z]+)?(\\s*?,\\s*?(\".*?\"|'.*?')\\s*?)?\\}"
     },
     "Aws.RestApiLogs": {
       "properties": {


### PR DESCRIPTION
This pull request allows trailing spaces before the closing brace and non-empty strings as the default value for resources.