### PR TITLE
Accept variable references as file default value and prevent third parameter

### DIFF
--- a/serverless/reference.json
+++ b/serverless/reference.json
@@ -40957,7 +40957,7 @@
     {
       "type": "string",
       "minLength": 1,
-      "pattern": "\\$\\{file\\(.+\\.(yml|yaml)\\)(:[A-Za-z]+)?(\\s*,\\s*(\".*\"|'.*')\\s*)?\\}"
+      "pattern": "\\$\\{file\\(.+\\.(yml|yaml)\\)(:[A-Za-z]+)?(\\s*,\\s*(\".*\"|'.*'|[A-Za-z:._-]+)\\s*)?\\}"
     },
     "Aws.RestApiLogs": {
       "properties": {

--- a/serverless/reference.json
+++ b/serverless/reference.json
@@ -40957,7 +40957,7 @@
     {
       "type": "string",
       "minLength": 1,
-      "pattern": "\\$\\{file\\(.+\\.(yml|yaml)\\)(:[A-Za-z]+)?(\\s*,\\s*(\".*\"|'.*'|[A-Za-z:._-]+)\\s*)?\\}"
+      "pattern": "\\$\\{file\\(.+\\.(yml|yaml)\\)(:[A-Za-z]+)?(\\s*,\\s*(\"[^,]*\"|'[^,]*'|[A-Za-z:._-]+)\\s*)?\\}"
     },
     "Aws.RestApiLogs": {
       "properties": {

--- a/serverless/reference.json
+++ b/serverless/reference.json
@@ -40957,7 +40957,7 @@
     {
       "type": "string",
       "minLength": 1,
-      "pattern": "\\$\\{file\\(.+\\.(yml|yaml)\\)(:[A-Za-z]+)?(\\s*?,\\s*?(\".*?\"|'.*?')\\s*?)?\\}"
+      "pattern": "\\$\\{file\\(.+\\.(yml|yaml)\\)(:[A-Za-z]+)?(\\s*,\\s*(\".*\"|'.*')\\s*)?\\}"
     },
     "Aws.RestApiLogs": {
       "properties": {

--- a/serverless/reference.json
+++ b/serverless/reference.json
@@ -40953,7 +40953,7 @@
         }
       ]
     },
-    "Serverless.FilePath": 
+    "Serverless.FilePath":
     {
       "type": "string",
       "minLength": 1,


### PR DESCRIPTION
This pull request accepts variable references as the default value and removes unneeded lazy quantifiers. The use of a third parameter is now also prevented.

Before:
![PixelSnap 2022-09-13 at 20 41 26@2x](https://user-images.githubusercontent.com/2276355/189984115-a842acf1-caad-4da7-975b-82bf78b913ac.png)

After:
![PixelSnap 2022-09-13 at 20 37 48@2x](https://user-images.githubusercontent.com/2276355/189984120-f2dd0575-340d-47a7-807c-b4c6f8409638.png)
