### PR TITLE
Change endpoint type to uppercase

### DIFF
--- a/serverless/reference.json
+++ b/serverless/reference.json
@@ -40683,7 +40683,7 @@
           "type": "string"
         },
         "endpointType": {
-          "enum": ["edge", "private", "regional"],
+          "enum": ["EDGE", "PRIVATE", "REGIONAL"],
           "type": "string"
         },
         "environment": {


### PR DESCRIPTION
This pull request changes endpoint types to uppercase, for Serverless case [doesn't matter](https://github.com/serverless/serverless/blob/38fe02ef81ac60967852dd4489e5f6dfec3ce3b3/lib/plugins/aws/package/compile/events/apiGateway/lib/restApi.js#L18-L31) but the Serverless/AWS documentation only use uppercase. It seems that similar existing enums are always uppercase such as `apiKeySourceType`.

Case insensitive enums aren't possible, it seems that to support true case insensitivity you need something [like this](https://stackoverflow.com/a/60022279/2693925).

