### PR TITLE
Add provider.httpApi Lambda Authorizer

### DIFF
--- a/serverless/reference.json
+++ b/serverless/reference.json
@@ -38120,6 +38120,9 @@
             "$ref": "#/definitions/Aws.CognitoAuthorizer"
           },
           {
+            "$ref": "#/definitions/Aws.LambdaAuthorizer"
+          },
+          {
             "$ref": "#/definitions/Aws.OidcAuthorizer"
           },
           {
@@ -40311,6 +40314,51 @@
         },
         "issuerUrl": {
           "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "Aws.LambdaAuthorizer": {
+      "properties": {
+        "type": {
+          "description": "Should be set to 'request' for custom Lambda authorizers",
+          "enum": ["request"],
+          "type": "string"
+        },
+        "authorizorFunc": {
+          "description": "Mutually exclusive with `functionArn`",
+          "type": "string"
+        },
+        "functionArn": {
+          "description": "Mutually exclusive with `functionName`",
+          "type": "string"
+        },
+        "name": {
+          "description": "Optional. Custom name for created authorizer",
+          "type": "string"
+        },
+        "resultTtlInSeconds": {
+          "description": "Optional. Time to live for cached authorizer results, accepts values from 0 (no caching) to 3600 (1 hour). When set to non-zero value, 'identitySource' must be defined as well",
+          "type": "number"
+        },
+        "enableSimpleResponses": {
+          "description": "Set if authorizer function will return authorization responses in simple format (default: false)",
+          "type": "boolean"
+        },
+        "payloadVersion": {
+          "description": "Version of payload that will be sent to authorizer function (default: '2.0')",
+          "type": "string"
+        },
+        "identitySource": {
+          "description": "Optional. One or more mapping expressions of the request parameters in form of e.g `$request.header.Auth`. Specified values are verified to be non-empty and not null by authorizer. It is a required property when `resultTtlInSeconds` is non-zero as `identitySource` is additionally used as cache key for authorizer responses caching.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }    
+        },
+        "managedExternally": {
+          "description": "Optional. Applicable only when using externally defined authorizer functions to prevent creation of permission resource",
+          "type": "boolean"
         }
       },
       "type": "object"


### PR DESCRIPTION
Fixes #54 

Adds definitions for [API Gateway V2 HTTP API](https://www.serverless.com/framework/docs/providers/aws/guide/serverless.yml#api-gateway-v2-http-api) custom Lambda authorizers.

This configuration is incorrectly marked invalid by the existing schema
```YAML
provider:
  name: aws
  httpApi:
    authorizers:
      customAuthorizer:
        type: request
        identitySource:
          - $request.header.Auth
          - $request.querystring.auth
```
          