### PR TITLE
Add definition for AWS::ApiGateway::RestApi - DisableExecuteApiEndpoint

### DIFF
--- a/serverless/reference.json
+++ b/serverless/reference.json
@@ -1609,6 +1609,17 @@
               "description": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-restapi.html#cfn-apigateway-restapi-description",
               "$ref": "#/definitions/Expression"
             },
+            "DisableExecuteApiEndpoint": {
+              "description": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-restapi.html#cfn-apigateway-restapi-disableexecuteapiendpoint",
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "$ref": "#/definitions/Expression"
+                }
+              ]
+            },
             "EndpointConfiguration": {
               "$ref": "#/definitions/AWS_ApiGateway_RestApi_EndpointConfiguration"
             },


### PR DESCRIPTION
Adds the definition for AWS::ApiGateway::RestApi - DisableExecuteApiEndpoint.

Fixes #56 