### PR TITLE
Add support for `Fn::ToJsonString`

### DIFF
--- a/serverless/reference.json
+++ b/serverless/reference.json
@@ -379,6 +379,9 @@
         },
         {
           "$ref": "#/definitions/FnSub"
+        },
+        {
+          "$ref": "#/definitions/FnToJsonString"
         }
       ]
     },
@@ -660,6 +663,16 @@
             }
           ],
           "minItems": 1
+        }
+      },
+      "additionalProperties": false
+    },
+    "FnToJsonString": {
+      "type": "object",
+      "properties": {
+        "Fn::ToJsonString": {
+          "description": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-ToJsonString.html",
+          "type": ["object", "array"]
         }
       },
       "additionalProperties": false


### PR DESCRIPTION
Adds support for the `Fn::ToJsonString` [intrinsic function](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-ToJsonString.html).

Previously:
<img width="721" alt="Screen Shot 2022-11-10 at 5 10 32 PM" src="https://user-images.githubusercontent.com/6936148/201000491-34de9a10-405e-420e-9031-e43331e556ec.png">
