### PR TITLE
Add support for FilterPolicyScope

### DIFF
--- a/serverless/reference.json
+++ b/serverless/reference.json
@@ -16080,6 +16080,11 @@
               "description": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sns-subscription.html#cfn-sns-endpoint",
               "$ref": "#/definitions/Expression"
             },
+            "FilterPolicyScope": {
+              "description": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sns-subscription.html#cfn-sns-subscription-filterpolicy",
+              "type": "string",
+              "enum": ["MessageAttributes", "MessageBody"]
+            },
             "FilterPolicy": {
               "description": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sns-subscription.html#cfn-sns-subscription-filterpolicy",
               "anyOf": [


### PR DESCRIPTION
# Changelog

- update `AWS_SNS_Subscription` schema definition it include `FilterPolicyScope` property for `MessageAttributes` and `MessageBody` enums