### PR TITLE
fix iam role statement resource

### DIFF
--- a/serverless/reference.json
+++ b/serverless/reference.json
@@ -39464,16 +39464,9 @@
           "anyOf": [
             {
               "items": {
-                "type": "string"
+                "$ref": "#/definitions/Expression"
               },
               "type": "array"
-            },
-            {
-              "additionalProperties": {},
-              "type": "object"
-            },
-            {
-              "type": "string"
             },
             {
               "$ref": "#/definitions/Expression"


### PR DESCRIPTION
- fix(provider): removed redundant string and string array and added array of Expression

## Overview

- Description: Expression already allows string literals to be used, so I removed string and array of string, also:- iam policy resource isn't an object, so I removed that too.
The reason for allowing array of expressions to be used is because it's a real use case and I just noticed it as I was testing it out.

For example, in this type of serverless configuration, the schema would consider it as being invalid, but that's not the case
![code](https://user-images.githubusercontent.com/29596786/208599619-bee5996a-e3a9-4418-82c8-d4da16aa29e9.png)

- Schema update type: modification
- Services affected: provider -> iamRoleStatements

## References

- [documentation/forum thread links]

## How was this tested?

[Describe what steps were taken to ensure this schema change is correct & necessary]
