### PR TITLE
fix: :bug: made both securityGroupIds and subnetIds required in vpc config

### DIFF
--- a/serverless/reference.json
+++ b/serverless/reference.json
@@ -40519,7 +40519,11 @@
           "type": "array"
         }
       },
-      "type": "object"
+      "type": "object",
+      "required": [
+        "securityGroupIds",
+        "subnetIds"
+      ]
     },
     "Aws.Websocket": {
       "properties": {


### PR DESCRIPTION
## Overview

- Description: Both of them are required when configuring VPC
- Schema update type: extend
- Services affected: 
VPC 

## References

https://www.serverless.com/framework/docs/providers/aws/guide/functions#vpc-configuration
