### PR TITLE
Add proper support for CF Intrinsic Functions

### DIFF
--- a/serverless/components/cf.functions.json
+++ b/serverless/components/cf.functions.json
@@ -1,0 +1,633 @@
+{
+  "id": "https://raw.githubusercontent.com/lalcebo/json-schema/master/serverless/components/common.json",
+  "schema": "https://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "description": "Collection of common object utility function",
+  "additionalProperties": false,
+  "FnBase64": {
+    "type": "object",
+    "properties": {
+      "Fn::Base64": {
+        "description": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-base64.html",
+        "oneOf": [
+            {
+                "$ref": "#/Aws.CF_Function"
+            },
+            {
+                "type": "string",
+                "description": "`valueToEncode`: The string value you want to convert to Base64."
+            }
+        ]
+      }
+    },
+    "additionalProperties": false
+  },
+  "FnCidr": {
+    "type": "object",
+    "properties": {
+      "Fn::Cidr": {
+        "description": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-cidr.html",
+        "type": "array",
+        "items": [
+          {
+            "description": "The user-specified CIDR address block to be split into smaller CIDR blocks.",
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "$ref": "#/FnRef"
+                },
+                {
+                    "$ref": "#/FnSelect"
+                }
+            ]
+          },
+          {
+            "description": "The number of CIDRs to generate. Valid range is between 1 and 256.",
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 256
+          },
+          {
+            "description": "The number of subnet bits for the CIDR. For example, specifying a value \"8\" for this parameter will create a CIDR with a mask of \"/24\".",
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 128
+          }
+        ],
+        "minItems": 2,
+        "maxItems": 3
+      }
+    },
+    "additionalProperties": false
+  },
+  "FnFindInMap": {
+    "type": "object",
+    "properties": {
+      "Fn::FindInMap": {
+        "description": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-findinmap.html",
+        "type": "array",
+        "items": [
+          {
+            "description": "The logical name of a mapping declared in the Mappings section that contains the keys and values.",
+            "type": "string"
+          },
+          {
+            "description": "The top-level key name. Its value is a list of key-value pairs.",
+            "oneOf": [
+                {
+                    "$ref": "#/FnFindInMap"
+                },
+                {
+                    "$ref": "#/FnRef"
+                },
+                {
+                    "type": "string"
+                }
+            ]
+          },
+          {
+            "description": "The second-level key name, which is set to one of the keys from the list assigned to TopLevelKey.",
+            "oneOf": [
+                {
+                    "$ref": "#/FnFindInMap"
+                },
+                {
+                    "$ref": "#/FnRef"
+                },
+                {
+                    "type": "string"
+                }
+            ]
+          }
+        ],
+        "minItems": 3,
+        "maxItems": 3
+      }
+    },
+    "additionalProperties": false
+  },
+  "FnGetAtt": {
+    "type": "object",
+    "properties": {
+      "Fn::GetAtt": {
+        "description": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-getatt.html",
+        "type": "array",
+        "items": [
+          {
+            "description": "The logical name (also called logical ID) of the resource that contains the attribute that you want.",
+            "type": "string"
+          },
+          {
+            "description": "The name of the resource-specific attribute whose value you want. See the resource's reference page for details about the attributes available for that resource type.",
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "$ref": "#/FnRef"
+                }
+            ]
+          }
+        ]
+      }
+    },
+    "additionalProperties": false
+  },
+  "FnGetAZs": {
+    "type": "object",
+    "properties": {
+      "Fn::GetAZs": {
+        "description": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-getavailabilityzones.html",
+        "oneOf": [
+            {
+                "$ref": "#/FnRef"
+            },
+            {
+                "type": "string"
+            }
+        ]
+      }
+    },
+    "additionalProperties": false
+  },
+  "FnImportValue": {
+    "type": "object",
+    "properties": {
+      "Fn::ImportValue": {
+        "description": "The stack output value that you want to import. Ref:- https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-importvalue.html",
+        "oneOf": [
+            {
+                "type": "string"
+            },
+            {
+                "$ref": "#/FnBase64"
+            },
+            {
+                "$ref": "#/FnFindInMap"
+            },
+            {
+                "$ref": "#/FnIf"
+            },
+            {
+                "$ref": "#/FnJoin"
+            },
+            {
+                "$ref": "#/FnSelect"
+            },
+            {
+                "$ref": "#/FnSplit"
+            },
+            {
+                "$ref": "#/FnSub"
+            },
+            {
+                "$ref": "#/FnRef"
+            }
+        ]
+      }
+    },
+    "additionalProperties": false
+  },
+  "FnJoin": {
+    "type": "object",
+    "properties": {
+      "Fn::Join": {
+        "description": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-join.html",
+        "type": "array",
+        "items": [
+          {
+            "description": "The value you want to occur between fragments. The delimiter will occur between fragments only. It will not terminate the final value.",
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "$ref": "#/FnBase64"
+                },
+                {
+                    "$ref": "#/FnFindInMap"
+                },
+                {
+                    "$ref": "#/FnGetAtt"
+                },
+                {
+                    "$ref": "#/FnGetAZs"
+                },
+                {
+                    "$ref": "#/FnIf"
+                },
+                {
+                    "$ref": "#/FnImportValue"
+                },
+                {
+                    "$ref": "#/FnJoin"
+                },
+                {
+                    "$ref": "#/FnSelect"
+                },
+                {
+                    "$ref": "#/FnSplit"
+                },
+                {
+                    "$ref": "#/FnSub"
+                },
+                {
+                    "$ref": "#/FnRef"
+                }
+            ]
+          },
+          {
+            "description": "The list of values you want combined.",
+            "type": "array"
+          }
+        ],
+        "minItems": 2
+      }
+    },
+    "additionalProperties": false
+  },
+  "FnRef": {
+    "oneOf": [
+      {
+        "description": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-ref.html",
+        "type": "object",
+        "properties": {
+          "Fn::Ref": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "description": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-ref.html",
+        "type": "object",
+        "properties": {
+          "Ref": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      }
+    ]
+  },
+  "FnSelect": {
+    "type": "object",
+    "properties": {
+      "Fn::Select": {
+        "description": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-select.html",
+        "type": "array",
+        "items": [
+          {
+            "description": "The index of the object to retrieve. This must be a value from zero to N-1, where N represents the number of elements in the array.",
+            "type": ["integer", "string"]
+          },
+          {
+            "description": "The list of objects to select from. This list must not be null, nor can it have null entries.",
+            "oneOf": [
+              {
+                "type": "array",
+                "items": { "type": "string" }
+              },
+              {
+                "$ref": "#/FnFindInMap"
+              },
+              {
+                "$ref": "#/FnGetAtt"
+              },
+              {
+                "$ref": "#/FnGetAZs"
+              },
+              {
+                "$ref": "#/FnIf"
+              },
+              {
+                "$ref": "#/FnSplit"
+              },
+              {
+                "$ref": "#/FnRef"
+              }
+            ],
+            "minItems": 1
+          }
+        ]
+      }
+    },
+    "additionalProperties": false
+  },
+  "FnSplit": {
+    "type": "object",
+    "properties": {
+      "Fn::Split": {
+        "description": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-split.html",
+        "type": "array",
+        "items": [
+          {
+            "description": "A string value that determines where the source string is divided.",
+            "type": "string"
+          },
+          {
+            "description": "The string value that you want to split.",
+            "oneOf": [
+              {
+                "description": "Literal string value",
+                "type": "string"
+              },
+              {
+                "$ref": "#/FnBase64"
+              },
+              {
+                "$ref": "#/FnFindInMap"
+              },
+              {
+                "$ref": "#/FnGetAtt"
+              },
+              {
+                "$ref": "#/FnGetAZs"
+              },
+              {
+                "$ref": "#/FnIf"
+              },
+              {
+                "$ref": "#/FnImportValue"
+              },
+              {
+                "$ref": "#/FnJoin"
+              },
+              {
+                "$ref": "#/FnSelect"
+              },
+              {
+                "$ref": "#/FnSub"
+              },
+              {
+                "$ref": "#/FnRef"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "additionalProperties": false
+  },
+  "FnSub": {
+    "type": "object",
+    "properties": {
+      "Fn::Sub": {
+        "description": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-sub.html",
+        "type": "array",
+        "items": [
+          {
+            "description": "A string with variables that AWS CloudFormation substitutes with their associated values at runtime. Write variables as ${MyVarName}. Variables can be template parameter names, resource logical IDs, resource attributes, or a variable in a key-value map. If you specify only template parameter names, resource logical IDs, and resource attributes, don't specify a key-value map.\nIf you specify template parameter names or resource logical IDs, such as ${InstanceTypeParameter}, AWS CloudFormation returns the same values as if you used the Ref intrinsic function. If you specify resource attributes, such as ${MyInstance.PublicIp}, AWS CloudFormation returns the same values as if you used the Fn::GetAtt intrinsic function.\nTo write a dollar sign and curly braces (${}) literally, add an exclamation point (!) after the open curly brace, such as ${!Literal}. AWS CloudFormation resolves this text as ${Literal}.",
+            "type": "string"
+          },
+          {
+            "description": "The name of a variable that you included in the String parameter.",
+            "type": "object",
+            "patternProperties": {
+              "^[a-zA-Z0-9._-]{1,255}$": {
+                "description": "The value that AWS CloudFormation substitutes for the associated variable name at runtime.",
+                "oneOf": [
+                  {
+                    "description": "Literal string value",
+                    "type": "string"
+                  },
+                  {
+                    "$ref": "#/FnBase64"
+                  },
+                  {
+                    "$ref": "#/FnFindInMap"
+                  },
+                  {
+                    "$ref": "#/FnGetAtt"
+                  },
+                  {
+                    "$ref": "#/FnGetAZs"
+                  },
+                  {
+                    "$ref": "#/FnIf"
+                  },
+                  {
+                    "$ref": "#/FnImportValue"
+                  },
+                  {
+                    "$ref": "#/FnJoin"
+                  },
+                  {
+                    "$ref": "#/FnSelect"
+                  },
+                  {
+                    "$ref": "#/FnRef"
+                  }
+                ]
+              }
+            },
+            "minProperties": 1
+          }
+        ],
+        "minItems": 1
+      }
+    },
+    "additionalProperties": false
+  },
+  "FnToJsonString": {
+    "type": "object",
+    "properties": {
+      "Fn::ToJsonString": {
+        "description": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-ToJsonString.html",
+        "type": ["object", "array"]
+      }
+    },
+    "additionalProperties": false
+  },
+  "FnTransform": {
+    "type": "object",
+    "properties": {
+      "Fn::Transform": {
+        "description": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-transform.html",
+        "type": "object",
+        "properties": {
+          "Name": {
+            "description": "The name of the macro you want to perform the processing.",
+            "$ref": "#/Condition"
+          },
+          "Parameters": {
+            "description": "The list parameters, specified as key-value pairs, to pass to the macro.",
+            "type": "object"
+          }
+        }
+      }
+    }
+  },
+  "FnAnd": {
+    "type": "object",
+    "properties": {
+      "Fn::And": {
+        "description": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-conditions.html#intrinsic-function-reference-conditions-and",
+        "type": "array",
+        "items": {
+          "$ref": "#/Condition"
+        },
+        "minItems": 2,
+        "maxItems": 10
+      }
+    },
+    "additionalProperties": false
+  },
+  "FnEquals": {
+    "type": "object",
+    "properties": {
+      "Fn::Equals": {
+        "description": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-conditions.html#intrinsic-function-reference-conditions-equals",
+        "type": "array",
+        "items": {
+          "$ref": "#/Aws.CF_Function"
+        },
+        "minItems": 2,
+        "maxItems": 2
+      }
+    },
+    "additionalProperties": false
+  },
+  "FnIf": {
+    "type": "object",
+    "properties": {
+      "Fn::If": {
+        "description": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-conditions.html#intrinsic-function-reference-conditions-if",
+        "type": "array",
+        "items": [
+          {
+            "type": "string"
+          },
+          {
+            "$ref": "#/Aws.CF_Function"
+          },
+          {
+            "$ref": "#/Aws.CF_Function"
+          }
+        ],
+        "minItems": 3,
+        "maxItems": 3
+      }
+    },
+    "additionalProperties": false
+  },
+  "FnNot": {
+    "type": "object",
+    "properties": {
+      "Fn::Not": {
+        "description": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-conditions.html#intrinsic-function-reference-conditions-not",
+        "type": "array",
+        "items": [
+          {
+            "$ref": "#/definitions/Condition"
+          }
+        ],
+        "minItems": 1,
+        "maxItems": 1
+      }
+    },
+    "additionalProperties": false
+  },
+  "FnOr": {
+    "type": "object",
+    "properties": {
+      "Fn::Or": {
+        "description": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-conditions.html#intrinsic-function-reference-conditions-or",
+        "type": "array",
+        "items": {
+          "$ref": "#/definitions/Condition"
+        },
+        "minItems": 2,
+        "maxItems": 10
+      }
+    },
+    "additionalProperties": false
+  },
+  "Condition": {
+    "description": "You can use intrinsic functions, such as Fn::If, Fn::Equals, and Fn::Not, to conditionally create stack resources. These conditions are evaluated based on input parameters that you declare when you create or update a stack. After you define all your conditions, you can associate them with resources or resource properties in the Resources and Outputs sections of a template.",
+    "type": "object",
+    "patternProperties": {
+      "^[a-zA-Z0-9._-]{1,255}$": {
+        "$ref": "#/ConditionalExpression"
+      }
+    },
+    "additionalProperties": false
+  },
+  "ConditionalExpression": {
+    "description": "Intrinsic function token expression or literal value",
+    "anyOf": [
+      {
+        "description": "Literal value",
+        "type": "string"
+      },
+      {
+        "$ref": "#/FnAnd"
+      },
+      {
+        "$ref": "#/FnEquals"
+      },
+      {
+        "$ref": "#/FnIf"
+      },
+      {
+        "$ref": "#/FnNot"
+      },
+      {
+        "$ref": "#/FnOr"
+      },
+      {
+        "$ref": "#/FnFindInMap"
+      },
+      {
+        "$ref": "#/FnRef"
+      }
+    ]
+  },
+  "Aws.CF_Function": {
+    "description": "Aws Cloudformation Intrinsic function token expression",
+    "anyOf": [
+      {
+        "$ref": "#/FnBase64"
+      },
+      {
+        "$ref": "#/FnCidr"
+      },
+      {
+        "$ref": "#/FnFindInMap"
+      },
+      {
+        "$ref": "#/FnGetAtt"
+      },
+      {
+        "$ref": "#/FnGetAZs"
+      },
+      {
+        "$ref": "#/FnImportValue"
+      },
+      {
+        "$ref": "#/FnJoin"
+      },
+      {
+        "$ref": "#/FnRef"
+      },
+      {
+        "$ref": "#/FnSelect"
+      },
+      {
+        "$ref": "#/FnSplit"
+      },
+      {
+        "$ref": "#/FnSub"
+      },
+      {
+        "$ref": "#/FnToJsonString"
+      }
+    ]
+  },
+  "required": [
+    "FnCidr",
+    "Aws.CF_Function"
+  ]
+}

--- a/serverless/reference.json
+++ b/serverless/reference.json
@@ -38879,7 +38879,7 @@
               "pattern": "^(arn:aws:([a-z]|-)+:([a-z]|[0-9]|-)*:[0-9]*:([a-z]|-)+:[a-zA-Z0-9-_.]+(:(\\$LATEST|[a-zA-Z0-9-_]+))?$)|(\\${.*\\})"
             },
             {
-              "$ref": "#/definitions/Expression"
+              "$ref": "components/cf.functions.json#/Aws.CF_Function"
             }
           ]
         },


### PR DESCRIPTION
## Overview

- Description: The current Expression definition is too broad and already supports any string or object value out of the box and sometimes when you want a custom configuration of string / object and CF functions, you can't use the Expression object, like in case of SF Task Resource

- Schema update type: [create and modification]
- Services affected: Step function -> Task -> Resource

## References

- https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html

## Nest steps
Slowly start migrating more CF functions to this file from Expression object.