### PR TITLE
fix: :truck: removed `.` from Aws.Functions and Aws.AwsFunction

### DIFF
--- a/serverless/reference.json
+++ b/serverless/reference.json
@@ -37363,7 +37363,7 @@
       },
       "type": "object"
     },
-    "Aws.AwsFunction": {
+    "AwsFunction": {
       "properties": {
         "awsKmsKeyArn": {
           "type": "string"
@@ -37876,13 +37876,13 @@
       },
       "type": "object"
     },
-    "Aws.Functions": {
-      "additionalProperties": {
-        "$ref": "#/definitions/Aws.AwsFunction"
-      },
+    "AwsFunctions": {
       "oneOf": [
         {
-          "type": "object"
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/AwsFunction"
+          }
         },
         {
           "type": "string",
@@ -39495,7 +39495,7 @@
       "type": "string"
     },
     "functions": {
-      "$ref": "#/definitions/Aws.Functions"
+      "$ref": "#/definitions/AwsFunctions"
     },
     "layers": {
       "$ref": "#/definitions/Aws.Layers"


### PR DESCRIPTION
## Overview

- Description: This is causing json-ts generators to break after dot
- Schema update type: modification
- Services affected: Functions