### PR TITLE
fix: :wrench: remove `.` after Aws from event names

### DIFF
--- a/serverless/reference.json
+++ b/serverless/reference.json
@@ -37189,7 +37189,7 @@
       },
       "type": "object"
     },
-    "Aws.AlbEvent": {
+    "AwsAlbEvent": {
       "properties": {
         "conditions": {
           "properties": {
@@ -37211,7 +37211,7 @@
       },
       "type": "object"
     },
-    "Aws.AlexaSkill": {
+    "AwsAlexaSkill": {
       "properties": {
         "appId": {
           "type": "string"
@@ -37222,7 +37222,7 @@
       },
       "type": "object"
     },
-    "Aws.AlexaSmartHome": {
+    "AwsAlexaSmartHome": {
       "properties": {
         "appId": {
           "type": "string"
@@ -37388,7 +37388,7 @@
         },
         "events": {
           "items": {
-            "$ref": "#/definitions/Aws.Event"
+            "$ref": "#/definitions/AwsEvent"
           },
           "type": "array"
         },
@@ -37514,7 +37514,7 @@
       },
       "type": "object"
     },
-    "Aws.CloudFront": {
+    "AwsCloudFront": {
       "properties": {
         "eventType": {
           "type": "string"
@@ -37531,7 +37531,7 @@
       },
       "type": "object"
     },
-    "Aws.CloudwatchEvent": {
+    "AwsCloudwatchEvent": {
       "properties": {
         "description": {
           "type": "string"
@@ -37620,7 +37620,7 @@
       },
       "required": ["source"]
     },
-    "Aws.CloudwatchLog": {
+    "AwsCloudwatchLog": {
       "properties": {
         "filter": {
           "type": "string"
@@ -37672,7 +37672,7 @@
       },
       "type": "object"
     },
-    "Aws.CognitoUserPool": {
+    "AwsCognitoUserPool": {
       "properties": {
         "existing": {
           "type": "boolean"
@@ -37783,48 +37783,48 @@
       "additionalProperties": {},
       "type": "object"
     },
-    "Aws.Event": {
+    "AwsEvent": {
       "properties": {
         "alb": {
-          "$ref": "#/definitions/Aws.AlbEvent"
+          "$ref": "#/definitions/AwsAlbEvent"
         },
         "alexaSkill": {
-          "$ref": "#/definitions/Aws.AlexaSkill"
+          "$ref": "#/definitions/AwsAlexaSkill"
         },
         "alexaSmartHome": {
-          "$ref": "#/definitions/Aws.AlexaSmartHome"
+          "$ref": "#/definitions/AwsAlexaSmartHome"
         },
         "cloudFront": {
-          "$ref": "#/definitions/Aws.CloudFront"
+          "$ref": "#/definitions/AwsCloudFront"
         },
         "cloudwatchEvent": {
-          "$ref": "#/definitions/Aws.CloudwatchEvent"
+          "$ref": "#/definitions/AwsCloudwatchEvent"
         },
         "cloudwatchLog": {
-          "$ref": "#/definitions/Aws.CloudwatchLog"
+          "$ref": "#/definitions/AwsCloudwatchLog"
         },
         "cognitoUserPool": {
-          "$ref": "#/definitions/Aws.CognitoUserPool"
+          "$ref": "#/definitions/AwsCognitoUserPool"
         },
         "eventBridge": {
-          "$ref": "#/definitions/Aws.EventBridge"
+          "$ref": "#/definitions/AwsEventBridge"
         },
         "http": {
-          "$ref": "#/definitions/Aws.Http"
+          "$ref": "#/definitions/AwsHttp"
         },
         "httpApi": {
-          "$ref": "#/definitions/Aws.HttpApiEvent"
+          "$ref": "#/definitions/AwsHttpApiEvent"
         },
         "iot": {
-          "$ref": "#/definitions/Aws.Iot"
+          "$ref": "#/definitions/AwsIot"
         },
         "s3": {
-          "$ref": "#/definitions/Aws.S3"
+          "$ref": "#/definitions/AwsS3"
         },
         "schedule": {
           "anyOf": [
             {
-              "$ref": "#/definitions/Aws.Schedule"
+              "$ref": "#/definitions/AwsSchedule"
             },
             {
               "type": "string"
@@ -37832,21 +37832,21 @@
           ]
         },
         "sns": {
-          "$ref": "#/definitions/Aws.Sns"
+          "$ref": "#/definitions/AwsSns"
         },
         "sqs": {
-          "$ref": "#/definitions/Aws.Sqs"
+          "$ref": "#/definitions/AwsSqs"
         },
         "stream": {
-          "$ref": "#/definitions/Aws.Stream"
+          "$ref": "#/definitions/AwsStream"
         },
         "websocket": {
-          "$ref": "#/definitions/Aws.Websocket"
+          "$ref": "#/definitions/AwsWebsocket"
         }
       },
       "type": "object"
     },
-    "Aws.EventBridge": {
+    "AwsEventBridge": {
       "properties": {
         "eventBus": {
           "type": "string"
@@ -37896,7 +37896,7 @@
         }
       ]
     },
-    "Aws.Http": {
+    "AwsHttp": {
       "oneOf": [
         {
           "properties": {
@@ -37991,7 +37991,7 @@
       },
       "type": "object"
     },
-    "Aws.HttpApiEvent": {
+    "AwsHttpApiEvent": {
       "oneOf": [
         {
           "properties": {
@@ -38299,7 +38299,7 @@
       },
       "type": "object"
     },
-    "Aws.Iot": {
+    "AwsIot": {
       "properties": {
         "description": {
           "type": "string"
@@ -39079,7 +39079,7 @@
       },
       "type": "object"
     },
-    "Aws.S3": {
+    "AwsS3": {
       "oneOf": [
         {
           "properties": {
@@ -39121,7 +39121,7 @@
       },
       "type": "object"
     },
-    "Aws.Schedule": {
+    "AwsSchedule": {
       "properties": {
         "description": {
           "type": "string"
@@ -39168,7 +39168,7 @@
       },
       "type": "object"
     },
-    "Aws.Sns": {
+    "AwsSns": {
       "properties": {
         "displayName": {
           "type": "string"
@@ -39201,7 +39201,7 @@
       },
       "type": "object"
     },
-    "Aws.Sqs": {
+    "AwsSqs": {
       "properties": {
         "arn": {
           "$ref": "#/definitions/Expression"
@@ -39229,7 +39229,7 @@
       },
       "type": "object"
     },
-    "Aws.Stream": {
+    "AwsStream": {
       "properties": {
         "arn": {
           "$ref": "#/definitions/Expression"
@@ -39306,7 +39306,7 @@
         "subnetIds"
       ]
     },
-    "Aws.Websocket": {
+    "AwsWebsocket": {
       "properties": {
         "authorizer": {
           "$ref": "#/definitions/Aws.WebsocketAuthorizer"


### PR DESCRIPTION
## Overview

- Description: Having a dot in the name was causing issues when generating types from this schema
- Schema update type: modification
- Services affected: 