### PR TITLE
feat: Add ItemBatcher, ItemProcessor, ItemReader support

### DIFF
--- a/serverless/plugin/step_functions.json
+++ b/serverless/plugin/step_functions.json
@@ -128,7 +128,7 @@
             {
               "oneOf": [
                 {
-                "$ref": "#/Aws_StateMachine_States_Map_Iterator"
+                  "$ref": "#/Aws_StateMachine_States_Map_Iterator"
                 },
                 {
                   "$ref": "#/Aws_StateMachine_States_Map_ItemProcessor"

--- a/serverless/plugin/step_functions.json
+++ b/serverless/plugin/step_functions.json
@@ -1170,22 +1170,12 @@
         "ProcessorConfig": {
           "type": ["object", "array"],
           "Mode": {
-            {
-              "type": "string",
-              "enum": ["DISTRIBUTED", "INLINE"]
-            }
+            "type": "string",
+            "enum": ["DISTRIBUTED", "INLINE"]
           },
           "ExecutionType": {
-            "oneOf": [
-              {
-                "type": "string",
-                "enum": ["STANDARD"]
-              },
-              {
-                "type": "string",
-                "enum": ["EXPRESS"]
-              }
-            ]
+            "type": "string",
+            "enum": ["STANDARD", "EXPRESS"]
           }
         }
       },

--- a/serverless/plugin/step_functions.json
+++ b/serverless/plugin/step_functions.json
@@ -126,7 +126,14 @@
               "$ref": "#/Aws_StateMachine_States_Wait"
             },
             {
-              "$ref": "#/Aws_StateMachine_States_Map"
+              "oneOf": [
+                {
+                "$ref": "#/Aws_StateMachine_States_Map_Iterator"
+                },
+                {
+                  "$ref": "#/Aws_StateMachine_States_Map_ItemProcessor"
+                }
+              ]
             }
           ]
         }
@@ -1123,48 +1130,95 @@
     ],
     "required": ["Type"]
   },
-  "Aws_StateMachine_States_Map": {
+  "Aws_StateMachine_States_Map_Properties": {
+    "Type": {
+      "type": "string",
+      "enum": ["Map"]
+    },
+    "Next": {
+      "type": "string"
+    },
+    "End": {
+      "enum": [true]
+    },
+    "Comment": {
+      "type": "string"
+    },
+    "OutputPath": {
+      "type": ["string", "null"]
+    },
+    "InputPath": {
+      "type": ["string", "null"]
+    },
+    "ResultPath": {
+      "type": ["string", "null"]
+    },
+    "ItemsPath": {
+      "type": ["string", "null"]
+    },
+    "MaxConcurrency": {
+      "type": "number",
+      "minimum": 0
+    },
+    "Parameters": {
+      "type": ["object", "array"],
+      "items": {
+        "type": "object"
+      }
+    },
+    "ResultSelector": {
+      "type": "object"
+    },
+    "Retry": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "ErrorEquals": {
+            "type": "array",
+            "items": {
+              "$ref": "#/Aws_StateMachine_Errors"
+            }
+          },
+          "IntervalSeconds": {
+            "type": "number",
+            "minimum": 0
+          },
+          "MaxAttempts": {
+            "type": "number",
+            "minimum": 0
+          },
+          "BackoffRate": {
+            "type": "number",
+            "minimum": 0
+          }
+        },
+        "required": ["ErrorEquals"]
+      }
+    },
+    "Catch": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "ErrorEquals": {
+            "type": "array",
+            "items": {
+              "$ref": "#/Aws_StateMachine_Errors"
+            }
+          },
+          "Next": {
+            "type": "string"
+          }
+        },
+        "required": ["ErrorEquals", "Next"]
+      }
+    }
+  },
+  "Aws_StateMachine_States_Map_ItemProcessor": {
     "type": "object",
     "properties": {
-      "Type": {
-        "type": "string",
-        "enum": ["Map"]
-      },
-      "Next": {
-        "type": "string"
-      },
-      "End": {
-        "enum": [true]
-      },
-      "Comment": {
-        "type": "string"
-      },
-      "OutputPath": {
-        "type": ["string", "null"]
-      },
-      "InputPath": {
-        "type": ["string", "null"]
-      },
-      "ResultPath": {
-        "type": ["string", "null"]
-      },
-      "ItemsPath": {
-        "type": ["string", "null"]
-      },
-      "MaxConcurrency": {
-        "type": "number",
-        "minimum": 0
-      },
-      "ItemBatcher": {
-        "type": ["object", "array"],
-        "MaxItemsPerBatch": {
-          "type": "number",
-          "minimum": 0
-        }
-      },
-      "Iterator": {
-        "$ref": "#/Aws_StateMachine_Definition"
-      },
+      "$ref": "#/Aws_StateMachine_States_Map_Properties",
       "ItemProcessor": {
         "$ref": "#/Aws_StateMachine_Definition",
         "ProcessorConfig": {
@@ -1179,62 +1233,15 @@
           }
         }
       },
+      "ItemBatcher": {
+        "type": ["object", "array"],
+        "MaxItemsPerBatch": {
+          "type": "number",
+          "minimum": 0
+        }
+      },
       "ItemReader": {
         "type": "object"
-      },
-      "Parameters": {
-        "type": ["object", "array"],
-        "items": {
-          "type": "object"
-        }
-      },
-      "ResultSelector": {
-        "type": "object"
-      },
-      "Retry": {
-        "type": "array",
-        "items": {
-          "type": "object",
-          "properties": {
-            "ErrorEquals": {
-              "type": "array",
-              "items": {
-                "$ref": "#/Aws_StateMachine_Errors"
-              }
-            },
-            "IntervalSeconds": {
-              "type": "number",
-              "minimum": 0
-            },
-            "MaxAttempts": {
-              "type": "number",
-              "minimum": 0
-            },
-            "BackoffRate": {
-              "type": "number",
-              "minimum": 0
-            }
-          },
-          "required": ["ErrorEquals"]
-        }
-      },
-      "Catch": {
-        "type": "array",
-        "items": {
-          "type": "object",
-          "properties": {
-            "ErrorEquals": {
-              "type": "array",
-              "items": {
-                "$ref": "#/Aws_StateMachine_Errors"
-              }
-            },
-            "Next": {
-              "type": "string"
-            }
-          },
-          "required": ["ErrorEquals", "Next"]
-        }
       }
     },
     "oneOf": [
@@ -1246,5 +1253,23 @@
       }
     ],
     "required": ["Type", "ItemProcessor"]
+  },
+  "Aws_StateMachine_States_Map_Iterator": {
+    "type": "object",
+    "properties": {
+      "$ref": "#/Aws_StateMachine_States_Map_Properties",
+      "Iterator": {
+        "$ref": "#/Aws_StateMachine_Definition"
+      }
+    },
+    "oneOf": [
+      {
+        "required": ["Next"]
+      },
+      {
+        "required": ["End"]
+      }
+    ],
+    "required": ["Type", "Iterator"]
   }
 }

--- a/serverless/plugin/step_functions.json
+++ b/serverless/plugin/step_functions.json
@@ -1126,111 +1126,90 @@
     ],
     "required": ["Type"]
   },
-  "Aws_StateMachine_States_Map_Properties": {
-    "Type": {
-      "type": "string",
-      "enum": ["Map"]
-    },
-    "Next": {
-      "type": "string"
-    },
-    "End": {
-      "enum": [true]
-    },
-    "Comment": {
-      "type": "string"
-    },
-    "OutputPath": {
-      "type": ["string", "null"]
-    },
-    "InputPath": {
-      "type": ["string", "null"]
-    },
-    "ResultPath": {
-      "type": ["string", "null"]
-    },
-    "ItemsPath": {
-      "type": ["string", "null"]
-    },
-    "MaxConcurrency": {
-      "type": "number",
-      "minimum": 0
-    },
-    "Parameters": {
-      "type": ["object", "array"],
-      "items": {
-        "type": "object"
-      }
-    },
-    "ResultSelector": {
-      "type": "object"
-    },
-    "Retry": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "properties": {
-          "ErrorEquals": {
-            "type": "array",
-            "items": {
-              "$ref": "#/Aws_StateMachine_Errors"
-            }
-          },
-          "IntervalSeconds": {
-            "type": "number",
-            "minimum": 0
-          },
-          "MaxAttempts": {
-            "type": "number",
-            "minimum": 0
-          },
-          "BackoffRate": {
-            "type": "number",
-            "minimum": 0
-          }
-        },
-        "required": ["ErrorEquals"]
-      }
-    },
-    "Catch": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "properties": {
-          "ErrorEquals": {
-            "type": "array",
-            "items": {
-              "$ref": "#/Aws_StateMachine_Errors"
-            }
-          },
-          "Next": {
-            "type": "string"
-          }
-        },
-        "required": ["ErrorEquals", "Next"]
-      }
-    }
-  },
   "Aws_StateMachine_States_Map_ItemProcessor": {
     "type": "object",
     "properties": {
-      "$ref": "#/Aws_StateMachine_States_Map_Properties",
-      "ItemProcessor": {
-        "$ref": "#/Aws_StateMachine_Definition",
-        "properties": {
-          "ProcessorConfig": {
-            "type": ["object"],
-            "properties": {
-              "Mode": {
-                "type": "string",
-                "enum": ["DISTRIBUTED", "INLINE"]
-              },
-              "ExecutionType": {
-                "type": "string",
-                "enum": ["STANDARD", "EXPRESS"]
+      "Type": {
+        "type": "string",
+        "enum": ["Map"]
+      },
+      "Next": {
+        "type": "string"
+      },
+      "End": {
+        "enum": [true]
+      },
+      "Comment": {
+        "type": "string"
+      },
+      "OutputPath": {
+        "type": ["string", "null"]
+      },
+      "InputPath": {
+        "type": ["string", "null"]
+      },
+      "ResultPath": {
+        "type": ["string", "null"]
+      },
+      "ItemsPath": {
+        "type": ["string", "null"]
+      },
+      "MaxConcurrency": {
+        "type": "number",
+        "minimum": 0
+      },
+      "Parameters": {
+        "type": ["object", "array"],
+        "items": {
+          "type": "object"
+        }
+      },
+      "ResultSelector": {
+        "type": "object"
+      },
+      "Retry": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "ErrorEquals": {
+              "type": "array",
+              "items": {
+                "$ref": "#/Aws_StateMachine_Errors"
               }
+            },
+            "IntervalSeconds": {
+              "type": "number",
+              "minimum": 0
+            },
+            "MaxAttempts": {
+              "type": "number",
+              "minimum": 0
+            },
+            "BackoffRate": {
+              "type": "number",
+              "minimum": 0
             }
-          }
+          },
+          "required": ["ErrorEquals"]
+        }
+      },
+      "Catch": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "ErrorEquals": {
+              "type": "array",
+              "items": {
+                "$ref": "#/Aws_StateMachine_Errors"
+              }
+            },
+            "Next": {
+              "type": "string"
+            }
+          },
+          "required": ["ErrorEquals", "Next"]
         }
       },
       "ItemBatcher": {
@@ -1256,6 +1235,24 @@
       },
       "ItemReader": {
         "type": "object"
+      },
+      "ItemProcessor": {
+        "$ref": "#/Aws_StateMachine_Definition",
+        "properties": {
+          "ProcessorConfig": {
+            "type": ["object"],
+            "properties": {
+              "Mode": {
+                "type": "string",
+                "enum": ["DISTRIBUTED", "INLINE"]
+              },
+              "ExecutionType": {
+                "type": "string",
+                "enum": ["STANDARD", "EXPRESS"]
+              }
+            }
+          }
+        }
       }
     },
     "oneOf": [
@@ -1271,7 +1268,113 @@
   "Aws_StateMachine_States_Map_Iterator": {
     "type": "object",
     "properties": {
-      "$ref": "#/Aws_StateMachine_States_Map_Properties",
+      "Type": {
+        "type": "string",
+        "enum": ["Map"]
+      },
+      "Next": {
+        "type": "string"
+      },
+      "End": {
+        "enum": [true]
+      },
+      "Comment": {
+        "type": "string"
+      },
+      "OutputPath": {
+        "type": ["string", "null"]
+      },
+      "InputPath": {
+        "type": ["string", "null"]
+      },
+      "ResultPath": {
+        "type": ["string", "null"]
+      },
+      "ItemsPath": {
+        "type": ["string", "null"]
+      },
+      "MaxConcurrency": {
+        "type": "number",
+        "minimum": 0
+      },
+      "Parameters": {
+        "type": ["object", "array"],
+        "items": {
+          "type": "object"
+        }
+      },
+      "ResultSelector": {
+        "type": "object"
+      },
+      "Retry": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "ErrorEquals": {
+              "type": "array",
+              "items": {
+                "$ref": "#/Aws_StateMachine_Errors"
+              }
+            },
+            "IntervalSeconds": {
+              "type": "number",
+              "minimum": 0
+            },
+            "MaxAttempts": {
+              "type": "number",
+              "minimum": 0
+            },
+            "BackoffRate": {
+              "type": "number",
+              "minimum": 0
+            }
+          },
+          "required": ["ErrorEquals"]
+        }
+      },
+      "Catch": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "ErrorEquals": {
+              "type": "array",
+              "items": {
+                "$ref": "#/Aws_StateMachine_Errors"
+              }
+            },
+            "Next": {
+              "type": "string"
+            }
+          },
+          "required": ["ErrorEquals", "Next"]
+        }
+      },
+      "ItemBatcher": {
+        "type": "object",
+        "properties": {
+          "MaxItemsPerBatch": {
+            "type": "number",
+            "minimum": 0
+          },
+          "MaxInputBytesPerBatchPath": {
+            "type": "number",
+            "minimum": 0
+          }
+        },
+        "oneOf": [
+          {
+            "required": ["MaxItemsPerBatch"]
+          },
+          {
+            "required": ["MaxInputBytesPerBatchPath"]
+          }
+        ]
+      },
+      "ItemReader": {
+        "type": "object"
+      },
       "Iterator": {
         "$ref": "#/Aws_StateMachine_Definition"
       }

--- a/serverless/plugin/step_functions.json
+++ b/serverless/plugin/step_functions.json
@@ -1170,16 +1170,10 @@
         "ProcessorConfig": {
           "type": ["object", "array"],
           "Mode": {
-            "oneOf": [
-              {
-                "type": "string",
-                "enum": ["DISTRIBUTED"]
-              },
-              {
-                "type": "string",
-                "enum": ["INLINE"]
-              }
-            ]
+            {
+              "type": "string",
+              "enum": ["DISTRIBUTED", "INLINE"]
+            }
           },
           "ExecutionType": {
             "oneOf": [

--- a/serverless/plugin/step_functions.json
+++ b/serverless/plugin/step_functions.json
@@ -126,14 +126,10 @@
               "$ref": "#/Aws_StateMachine_States_Wait"
             },
             {
-              "oneOf": [
-                {
-                  "$ref": "#/Aws_StateMachine_States_Map_Iterator"
-                },
-                {
-                  "$ref": "#/Aws_StateMachine_States_Map_ItemProcessor"
-                }
-              ]
+              "$ref": "#/Aws_StateMachine_States_Map_Iterator"
+            },
+            {
+              "$ref": "#/Aws_StateMachine_States_Map_ItemProcessor"
             }
           ]
         }

--- a/serverless/plugin/step_functions.json
+++ b/serverless/plugin/step_functions.json
@@ -1155,8 +1155,48 @@
         "type": "number",
         "minimum": 0
       },
+      "ItemBatcher": {
+        "type": ["object", "array"],
+        "MaxItemsPerBatch": {
+          "type": "number",
+          "minimum": 0
+        }
+      },
       "Iterator": {
         "$ref": "#/Aws_StateMachine_Definition"
+      },
+      "ItemProcessor": {
+        "$ref": "#/Aws_StateMachine_Definition",
+        "ProcessorConfig": {
+          "type": ["object", "array"],
+          "Mode": {
+            "oneOf": [
+              {
+                "type": "string",
+                "enum": ["DISTRIBUTED"]
+              },
+              {
+                "type": "string",
+                "enum": ["INLINE"]
+              }
+            ]
+          },
+          "ExecutionType": {
+            "oneOf": [
+              {
+                "type": "string",
+                "enum": ["STANDARD"]
+              },
+              {
+                "type": "string",
+                "enum": ["EXPRESS"]
+              }
+            ]
+          }
+        }
+      },
+      "ItemReader": {
+        "type": "object"
       },
       "Parameters": {
         "type": ["object", "array"],
@@ -1221,6 +1261,6 @@
         "required": ["End"]
       }
     ],
-    "required": ["Type", "Iterator"]
+    "required": ["Type", "ItemProcessor"]
   }
 }

--- a/serverless/plugin/step_functions.json
+++ b/serverless/plugin/step_functions.json
@@ -1221,24 +1221,42 @@
       "$ref": "#/Aws_StateMachine_States_Map_Properties",
       "ItemProcessor": {
         "$ref": "#/Aws_StateMachine_Definition",
-        "ProcessorConfig": {
-          "type": ["object", "array"],
-          "Mode": {
-            "type": "string",
-            "enum": ["DISTRIBUTED", "INLINE"]
-          },
-          "ExecutionType": {
-            "type": "string",
-            "enum": ["STANDARD", "EXPRESS"]
+        "properties": {
+          "ProcessorConfig": {
+            "type": ["object"],
+            "properties": {
+              "Mode": {
+                "type": "string",
+                "enum": ["DISTRIBUTED", "INLINE"]
+              },
+              "ExecutionType": {
+                "type": "string",
+                "enum": ["STANDARD", "EXPRESS"]
+              }
+            }
           }
         }
       },
       "ItemBatcher": {
-        "type": ["object", "array"],
-        "MaxItemsPerBatch": {
-          "type": "number",
-          "minimum": 0
-        }
+        "type": "object",
+        "properties": {
+          "MaxItemsPerBatch": {
+            "type": "number",
+            "minimum": 0
+          },
+          "MaxInputBytesPerBatchPath": {
+            "type": "number",
+            "minimum": 0
+          }
+        },
+        "oneOf": [
+          {
+            "required": ["MaxItemsPerBatch"]
+          },
+          {
+            "required": ["MaxInputBytesPerBatchPath"]
+          }
+        ]
       },
       "ItemReader": {
         "type": "object"


### PR DESCRIPTION
## Overview

- Description: AWS Step Functions has added supported for distributed map processing which required additional configs. `Iterator` is deprecated so I made `ItemProcessor` as required.
- Schema update type:  create, modification
- Services affected: Step Functions

## References

- [AWS documentation for distributed map](https://docs.aws.amazon.com/step-functions/latest/dg/concepts-asl-use-map-state-distributed.html)
- `Iterator` is deprecated. More info [here](https://docs.aws.amazon.com/step-functions/latest/dg/concepts-asl-use-map-state-inline.html) 

## How was this tested?

[Describe what steps were taken to ensure this schema change is correct & necessary]
- I connected the reference.json to my intellij locally and tested out the new changes.