### PR TITLE
fix: :truck: removed . from iamRoleStatement, apiGatewayconfig and bucket config

### DIFF
--- a/serverless/reference.json
+++ b/serverless/reference.json
@@ -37169,7 +37169,7 @@
       },
       "type": "object"
     },
-    "Aws.ApiGateway": {
+    "AwsApiGateway": {
       "properties": {
         "apiKeySourceType": {
           "type": "string",
@@ -37651,7 +37651,7 @@
       },
       "type": "object"
     },
-    "Aws.DeploymentBucket": {
+    "AwsDeploymentBucket": {
       "description": "Configure the S3 bucket used by Serverless Framework to deploy code packages to Lambda",
       "properties": {
         "blockPublicAccess": {
@@ -38117,7 +38117,7 @@
       },
       "type": "object"
     },
-    "Aws.IamRoleStatement": {
+    "AwsIamRoleStatement": {
       "properties": {
         "Action": {
           "anyOf": [
@@ -38669,7 +38669,7 @@
               }
             },
             "apiGateway": {
-              "$ref": "#/definitions/Aws.ApiGateway"
+              "$ref": "#/definitions/AwsApiGateway"
             },
             "apiKeys": {
               "items": {
@@ -38685,7 +38685,7 @@
               "type": "string"
             },
             "deploymentBucket": {
-              "$ref": "#/definitions/Aws.DeploymentBucket"
+              "$ref": "#/definitions/AwsDeploymentBucket"
             },
             "deploymentPrefix": {
               "type": "string"
@@ -38708,7 +38708,7 @@
             },
             "iamRoleStatements": {
               "items": {
-                "$ref": "#/definitions/Aws.IamRoleStatement"
+                "$ref": "#/definitions/AwsIamRoleStatement"
               },
               "type": "array"
             },


### PR DESCRIPTION
## Overview

- Description: Having a dot in the name breaks codegen for TS support.
- Schema update type: modification
- Services affected: 