### PR TITLE
Change AWS_DynamoDB_Table_AttributeDefinition type

### DIFF
--- a/serverless/reference.json
+++ b/serverless/reference.json
@@ -24390,23 +24390,16 @@
     },
     "AWS_DynamoDB_Table_AttributeDefinition": {
       "type": "object",
-      "description": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-dynamodb-attributedef.html",
+      "description": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-dynamodb-table-attributedefinition.html",
       "properties": {
         "AttributeName": {
-          "description": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-dynamodb-attributedef.html#cfn-dynamodb-attributedef-attributename",
+          "description": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-dynamodb-table-attributedefinition.html#cfn-dynamodb-attributedef-attributename",
           "$ref": "#/definitions/Expression"
         },
         "AttributeType": {
-          "description": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-dynamodb-attributedef.html#cfn-dynamodb-attributedef-attributename-attributetype",
-          "oneOf": [
-            {
-              "$ref": "#/definitions/Expression"
-            },
-            {
-              "type": "string",
-              "enum": ["S", "N", "B"]
-            }
-          ]
+          "description": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-dynamodb-table-attributedefinition.html#cfn-dynamodb-attributedef-attributename-attributetype",
+          "type": "string",
+          "enum": ["S", "N", "B"]
         }
       },
       "required": ["AttributeName", "AttributeType"]


### PR DESCRIPTION
## Overview

- Description: Change AWS_DynamoDB_Table_AttributeDefinition type according to https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-dynamodb-table-attributedefinition.html
- Schema update type: modification
- Services affected: DynamoDB

## References

- https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-dynamodb-table-attributedefinition.html

## How was this tested?

Before the change:

<img width="687" alt="image" src="https://user-images.githubusercontent.com/5099618/214724813-ff53763e-38d1-4af8-9787-298555239f48.png">
_Schema validation: Validates to more than one variant_ 

After the change: (no warnings)
<img width="477" alt="image" src="https://user-images.githubusercontent.com/5099618/214724888-8fa42084-dbd2-4518-a483-4b33a4801a2f.png">

Also, before the change, when table have multiple attributes:

<img width="1119" alt="image" src="https://user-images.githubusercontent.com/5099618/214725040-5028d824-6015-4667-8f2d-244a1ce1d0e4.png">
Honestly I don't gully understand why but I get this warning for the whole section of resource: `Schema validation: Value should be one of: "AWS::AppSync::DomainName", "AWS::AppSync::DomainNameApiAssociation", "AWS::Cognito::UserPoolUICustomizationAttachment", "AWS::Serverless::Api`

After the change, when table have multiple attributes:
<img width="970" alt="image" src="https://user-images.githubusercontent.com/5099618/214725254-475171ce-415e-4802-a402-95539b9d99fd.png">
No warnings


