### PR TITLE
feat: :sparkles: updated source schema for DynamoDB GlobalTable

### DIFF
--- a/serverless/resources/cloudformation-modified/aws-dynamodb-globaltable.json
+++ b/serverless/resources/cloudformation-modified/aws-dynamodb-globaltable.json
@@ -100,6 +100,28 @@
       ],
       "title": "AWSDynamoDBGlobalTableStreamSpecificationDefinition"
     },
+    "KinesisStreamSpecification": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "StreamArn": {
+          "oneOf": [
+            {
+              "type": "string",
+              "minLength": 37,
+              "maxLength": 1024
+            },
+            {
+              "$ref": "../../components/cf.functions.json#/Aws_CF_FunctionString"
+            }
+          ]
+        }
+      },
+      "required": [
+        "StreamArn"
+      ],
+      "title": "AWSDynamoDBGlobalTableKinesisStreamSpecificationDefinition"
+    },
     "KeySchema": {
       "type": "object",
       "additionalProperties": false,
@@ -194,6 +216,9 @@
         },
         "ReadProvisionedThroughputSettings": {
           "$ref": "#/definitions/ReadProvisionedThroughputSettings"
+        },
+        "KinesisStreamSpecification": {
+          "$ref": "#/definitions/KinesisStreamSpecification"
         }
       },
       "required": [
@@ -595,6 +620,7 @@
         "dynamodb:TagResource",
         "dynamodb:EnableKinesisStreamingDestination",
         "dynamodb:DisableKinesisStreamingDestination",
+        "dynamodb:DescribeKinesisStreamingDestination",
         "dynamodb:DescribeTableReplicaAutoScaling",
         "dynamodb:UpdateTableReplicaAutoScaling",
         "dynamodb:TagResource",
@@ -605,6 +631,9 @@
         "application-autoscaling:PutScalingPolicy",
         "application-autoscaling:PutScheduledAction",
         "application-autoscaling:RegisterScalableTarget",
+        "kinesis:ListStreams",
+        "kinesis:DescribeStream",
+        "kinesis:PutRecords",
         "kms:CreateGrant",
         "kms:Describe*",
         "kms:Get*",
@@ -643,6 +672,7 @@
         "dynamodb:UntagResource",
         "dynamodb:EnableKinesisStreamingDestination",
         "dynamodb:DisableKinesisStreamingDestination",
+        "dynamodb:DescribeKinesisStreamingDestination",
         "dynamodb:DescribeTableReplicaAutoScaling",
         "dynamodb:UpdateTableReplicaAutoScaling",
         "application-autoscaling:DeleteScalingPolicy",
@@ -652,6 +682,9 @@
         "application-autoscaling:PutScalingPolicy",
         "application-autoscaling:PutScheduledAction",
         "application-autoscaling:RegisterScalableTarget",
+        "kinesis:ListStreams",
+        "kinesis:DescribeStream",
+        "kinesis:PutRecords",
         "kms:CreateGrant",
         "kms:Describe*",
         "kms:Get*",

--- a/serverless/resources/cloudformation/aws-dynamodb-globaltable.json
+++ b/serverless/resources/cloudformation/aws-dynamodb-globaltable.json
@@ -85,6 +85,18 @@
       },
       "required" : [ "StreamViewType" ]
     },
+    "KinesisStreamSpecification" : {
+      "type" : "object",
+      "additionalProperties" : false,
+      "properties" : {
+        "StreamArn" : {
+          "type" : "string",
+          "minLength": 37,
+          "maxLength": 1024
+        }
+      },
+      "required" : [ "StreamArn" ]
+    },
     "KeySchema" : {
       "type" : "object",
       "additionalProperties" : false,
@@ -146,6 +158,9 @@
         },
         "ReadProvisionedThroughputSettings" : {
           "$ref" : "#/definitions/ReadProvisionedThroughputSettings"
+        },
+        "KinesisStreamSpecification" : {
+          "$ref" : "#/definitions/KinesisStreamSpecification"
         }
       },
       "required" : [ "Region" ]
@@ -384,13 +399,13 @@
   "additionalIdentifiers" : [ [ "/properties/Arn" ], [ "/properties/StreamArn" ] ],
   "handlers" : {
     "create" : {
-      "permissions" : [ "dynamodb:CreateTable", "dynamodb:CreateTableReplica", "dynamodb:Describe*", "dynamodb:UpdateTimeToLive", "dynamodb:UpdateContributorInsights", "dynamodb:UpdateContinuousBackups", "dynamodb:ListTagsOfResource", "dynamodb:Query", "dynamodb:Scan", "dynamodb:UpdateItem", "dynamodb:PutItem", "dynamodb:GetItem", "dynamodb:DeleteItem", "dynamodb:BatchWriteItem", "dynamodb:TagResource", "dynamodb:EnableKinesisStreamingDestination", "dynamodb:DisableKinesisStreamingDestination", "dynamodb:DescribeTableReplicaAutoScaling", "dynamodb:UpdateTableReplicaAutoScaling", "dynamodb:TagResource", "application-autoscaling:DeleteScalingPolicy", "application-autoscaling:DeleteScheduledAction", "application-autoscaling:DeregisterScalableTarget", "application-autoscaling:Describe*", "application-autoscaling:PutScalingPolicy", "application-autoscaling:PutScheduledAction", "application-autoscaling:RegisterScalableTarget", "kms:CreateGrant", "kms:Describe*", "kms:Get*", "kms:List*", "kms:RevokeGrant", "cloudwatch:PutMetricData" ]
+      "permissions" : [ "dynamodb:CreateTable", "dynamodb:CreateTableReplica", "dynamodb:Describe*", "dynamodb:UpdateTimeToLive", "dynamodb:UpdateContributorInsights", "dynamodb:UpdateContinuousBackups", "dynamodb:ListTagsOfResource", "dynamodb:Query", "dynamodb:Scan", "dynamodb:UpdateItem", "dynamodb:PutItem", "dynamodb:GetItem", "dynamodb:DeleteItem", "dynamodb:BatchWriteItem", "dynamodb:TagResource", "dynamodb:EnableKinesisStreamingDestination", "dynamodb:DisableKinesisStreamingDestination", "dynamodb:DescribeKinesisStreamingDestination", "dynamodb:DescribeTableReplicaAutoScaling", "dynamodb:UpdateTableReplicaAutoScaling", "dynamodb:TagResource", "application-autoscaling:DeleteScalingPolicy", "application-autoscaling:DeleteScheduledAction", "application-autoscaling:DeregisterScalableTarget", "application-autoscaling:Describe*", "application-autoscaling:PutScalingPolicy", "application-autoscaling:PutScheduledAction", "application-autoscaling:RegisterScalableTarget", "kinesis:ListStreams", "kinesis:DescribeStream", "kinesis:PutRecords", "kms:CreateGrant", "kms:Describe*", "kms:Get*", "kms:List*", "kms:RevokeGrant", "cloudwatch:PutMetricData" ]
     },
     "read" : {
       "permissions" : [ "dynamodb:Describe*", "application-autoscaling:Describe*", "cloudwatch:PutMetricData" ]
     },
     "update" : {
-      "permissions" : [ "dynamodb:Describe*", "dynamodb:CreateTableReplica", "dynamodb:UpdateTable", "dynamodb:UpdateTimeToLive", "dynamodb:UpdateContinuousBackups", "dynamodb:UpdateContributorInsights", "dynamodb:ListTagsOfResource", "dynamodb:Query", "dynamodb:Scan", "dynamodb:UpdateItem", "dynamodb:PutItem", "dynamodb:GetItem", "dynamodb:DeleteItem", "dynamodb:BatchWriteItem", "dynamodb:DeleteTable", "dynamodb:DeleteTableReplica", "dynamodb:UpdateItem", "dynamodb:TagResource", "dynamodb:UntagResource", "dynamodb:EnableKinesisStreamingDestination", "dynamodb:DisableKinesisStreamingDestination", "dynamodb:DescribeTableReplicaAutoScaling", "dynamodb:UpdateTableReplicaAutoScaling", "application-autoscaling:DeleteScalingPolicy", "application-autoscaling:DeleteScheduledAction", "application-autoscaling:DeregisterScalableTarget", "application-autoscaling:Describe*", "application-autoscaling:PutScalingPolicy", "application-autoscaling:PutScheduledAction", "application-autoscaling:RegisterScalableTarget", "kms:CreateGrant", "kms:Describe*", "kms:Get*", "kms:List*", "kms:RevokeGrant", "cloudwatch:PutMetricData" ],
+      "permissions" : [ "dynamodb:Describe*", "dynamodb:CreateTableReplica", "dynamodb:UpdateTable", "dynamodb:UpdateTimeToLive", "dynamodb:UpdateContinuousBackups", "dynamodb:UpdateContributorInsights", "dynamodb:ListTagsOfResource", "dynamodb:Query", "dynamodb:Scan", "dynamodb:UpdateItem", "dynamodb:PutItem", "dynamodb:GetItem", "dynamodb:DeleteItem", "dynamodb:BatchWriteItem", "dynamodb:DeleteTable", "dynamodb:DeleteTableReplica", "dynamodb:UpdateItem", "dynamodb:TagResource", "dynamodb:UntagResource", "dynamodb:EnableKinesisStreamingDestination", "dynamodb:DisableKinesisStreamingDestination", "dynamodb:DescribeKinesisStreamingDestination", "dynamodb:DescribeTableReplicaAutoScaling", "dynamodb:UpdateTableReplicaAutoScaling", "application-autoscaling:DeleteScalingPolicy", "application-autoscaling:DeleteScheduledAction", "application-autoscaling:DeregisterScalableTarget", "application-autoscaling:Describe*", "application-autoscaling:PutScalingPolicy", "application-autoscaling:PutScheduledAction", "application-autoscaling:RegisterScalableTarget", "kinesis:ListStreams", "kinesis:DescribeStream", "kinesis:PutRecords", "kms:CreateGrant", "kms:Describe*", "kms:Get*", "kms:List*", "kms:RevokeGrant", "cloudwatch:PutMetricData" ],
       "timeoutInMinutes" : 1200
     },
     "delete" : {


### PR DESCRIPTION
The source from CF has been updated and I've just extended it and added it here
Only difference is that KinesisStreamSpecification has been added to Global DynamoDB table.
