### PR TITLE
fix: :wrench: remove `resource-schema.json` from ref

### DIFF
--- a/serverless/resources/cloudformation-modified/aws-nimblestudio-launchprofile.json
+++ b/serverless/resources/cloudformation-modified/aws-nimblestudio-launchprofile.json
@@ -410,7 +410,7 @@
       "handlerSchema": {
         "properties": {
           "StudioId": {
-            "$ref": "resource-schema.json#/properties/StudioId"
+            "$ref": "#/properties/StudioId"
           }
         },
         "required": [

--- a/serverless/resources/cloudformation-modified/aws-nimblestudio-streamingimage.json
+++ b/serverless/resources/cloudformation-modified/aws-nimblestudio-streamingimage.json
@@ -176,7 +176,7 @@
       "handlerSchema": {
         "properties": {
           "StudioId": {
-            "$ref": "resource-schema.json#/properties/StudioId"
+            "$ref": "#/properties/StudioId"
           }
         },
         "required": [

--- a/serverless/resources/cloudformation-modified/aws-nimblestudio-studiocomponent.json
+++ b/serverless/resources/cloudformation-modified/aws-nimblestudio-studiocomponent.json
@@ -559,7 +559,7 @@
       "handlerSchema": {
         "properties": {
           "StudioId": {
-            "$ref": "resource-schema.json#/properties/StudioId"
+            "$ref": "#/properties/StudioId"
           }
         },
         "required": [

--- a/serverless/resources/cloudformation/aws-nimblestudio-launchprofile.json
+++ b/serverless/resources/cloudformation/aws-nimblestudio-launchprofile.json
@@ -260,7 +260,7 @@
       "handlerSchema" : {
         "properties" : {
           "StudioId" : {
-            "$ref" : "resource-schema.json#/properties/StudioId"
+            "$ref" : "#/properties/StudioId"
           }
         },
         "required" : [ "StudioId" ]

--- a/serverless/resources/cloudformation/aws-nimblestudio-streamingimage.json
+++ b/serverless/resources/cloudformation/aws-nimblestudio-streamingimage.json
@@ -105,7 +105,7 @@
       "handlerSchema" : {
         "properties" : {
           "StudioId" : {
-            "$ref" : "resource-schema.json#/properties/StudioId"
+            "$ref" : "#/properties/StudioId"
           }
         },
         "required" : [ "StudioId" ]

--- a/serverless/resources/cloudformation/aws-nimblestudio-studiocomponent.json
+++ b/serverless/resources/cloudformation/aws-nimblestudio-studiocomponent.json
@@ -310,7 +310,7 @@
       "handlerSchema" : {
         "properties" : {
           "StudioId" : {
-            "$ref" : "resource-schema.json#/properties/StudioId"
+            "$ref" : "#/properties/StudioId"
           }
         },
         "required" : [ "StudioId" ]


### PR DESCRIPTION
Someone at AWS messed up and started referencing from a file that was not included in the schema. Fortunately the property that was referenced was in every schema file with this issue, so all I had to do was remove it
