### PR TITLE
fix: :wrench: started supporting direct string values inside of FnSub

### DIFF
--- a/serverless/components/cf.functions.json
+++ b/serverless/components/cf.functions.json
@@ -387,57 +387,64 @@
     "properties": {
       "Fn::Sub": {
         "description": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-sub.html",
-        "type": "array",
-        "items": [
+        "oneOf": [
           {
-            "description": "A string with variables that AWS CloudFormation substitutes with their associated values at runtime. Write variables as ${MyVarName}. Variables can be template parameter names, resource logical IDs, resource attributes, or a variable in a key-value map. If you specify only template parameter names, resource logical IDs, and resource attributes, don't specify a key-value map.\nIf you specify template parameter names or resource logical IDs, such as ${InstanceTypeParameter}, AWS CloudFormation returns the same values as if you used the Ref intrinsic function. If you specify resource attributes, such as ${MyInstance.PublicIp}, AWS CloudFormation returns the same values as if you used the Fn::GetAtt intrinsic function.\nTo write a dollar sign and curly braces (${}) literally, add an exclamation point (!) after the open curly brace, such as ${!Literal}. AWS CloudFormation resolves this text as ${Literal}.",
-            "type": "string"
+            "type": "array",
+            "items": [
+              {
+                "description": "A string with variables that AWS CloudFormation substitutes with their associated values at runtime. Write variables as ${MyVarName}. Variables can be template parameter names, resource logical IDs, resource attributes, or a variable in a key-value map. If you specify only template parameter names, resource logical IDs, and resource attributes, don't specify a key-value map.\nIf you specify template parameter names or resource logical IDs, such as ${InstanceTypeParameter}, AWS CloudFormation returns the same values as if you used the Ref intrinsic function. If you specify resource attributes, such as ${MyInstance.PublicIp}, AWS CloudFormation returns the same values as if you used the Fn::GetAtt intrinsic function.\nTo write a dollar sign and curly braces (${}) literally, add an exclamation point (!) after the open curly brace, such as ${!Literal}. AWS CloudFormation resolves this text as ${Literal}.",
+                "type": "string"
+              },
+              {
+                "description": "The name of a variable that you included in the String parameter.",
+                "type": "object",
+                "patternProperties": {
+                  "^[a-zA-Z0-9._-]{1,255}$": {
+                    "description": "The value that AWS CloudFormation substitutes for the associated variable name at runtime.",
+                    "oneOf": [
+                      {
+                        "description": "Literal string value",
+                        "type": "string"
+                      },
+                      {
+                        "$ref": "#/FnBase64"
+                      },
+                      {
+                        "$ref": "#/FnFindInMap"
+                      },
+                      {
+                        "$ref": "#/FnGetAtt"
+                      },
+                      {
+                        "$ref": "#/FnGetAZs"
+                      },
+                      {
+                        "$ref": "#/FnIf"
+                      },
+                      {
+                        "$ref": "#/FnImportValue"
+                      },
+                      {
+                        "$ref": "#/FnJoin"
+                      },
+                      {
+                        "$ref": "#/FnSelect"
+                      },
+                      {
+                        "$ref": "#/FnRef"
+                      }
+                    ]
+                  }
+                },
+                "minProperties": 1
+              }
+            ],
+            "minItems": 1
           },
           {
-            "description": "The name of a variable that you included in the String parameter.",
-            "type": "object",
-            "patternProperties": {
-              "^[a-zA-Z0-9._-]{1,255}$": {
-                "description": "The value that AWS CloudFormation substitutes for the associated variable name at runtime.",
-                "oneOf": [
-                  {
-                    "description": "Literal string value",
-                    "type": "string"
-                  },
-                  {
-                    "$ref": "#/FnBase64"
-                  },
-                  {
-                    "$ref": "#/FnFindInMap"
-                  },
-                  {
-                    "$ref": "#/FnGetAtt"
-                  },
-                  {
-                    "$ref": "#/FnGetAZs"
-                  },
-                  {
-                    "$ref": "#/FnIf"
-                  },
-                  {
-                    "$ref": "#/FnImportValue"
-                  },
-                  {
-                    "$ref": "#/FnJoin"
-                  },
-                  {
-                    "$ref": "#/FnSelect"
-                  },
-                  {
-                    "$ref": "#/FnRef"
-                  }
-                ]
-              }
-            },
-            "minProperties": 1
+            "type": "string"
           }
-        ],
-        "minItems": 1
+        ]
       }
     },
     "additionalProperties": false


### PR DESCRIPTION
## Overview

- Description: Fn:Sub allows directly substituting inside a string containing known variables
- Schema update type: modification

## References
https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-sub.html
