### PR TITLE
Add AWS Resource Schemas

### DIFF
--- a/serverless/reference.json
+++ b/serverless/reference.json
@@ -2,7 +2,10 @@
   "$schema": "https://json-schema.org/draft-07/schema#",
   "title": "ServerlessFrameworkConfiguration",
   "description": "Schema for serverless framework configuration files",
-  "fileMatch": ["serverless.yml", "serverless.yaml"],
+  "fileMatch": [
+    "serverless.yml",
+    "serverless.yaml"
+  ],
   "definitions": {
     "Transform": {
       "type": "object",
@@ -57,7 +60,10 @@
       "properties": {
         "apiKeySourceType": {
           "type": "string",
-          "enum": ["HEADER", "AUTHORIZER"]
+          "enum": [
+            "HEADER",
+            "AUTHORIZER"
+          ]
         },
         "binaryMediaTypes": {
           "description": "Optional binary media types the API might return",
@@ -223,7 +229,10 @@
           "type": "array"
         },
         "memorySize": {
-          "type": ["string", "number"]
+          "type": [
+            "string",
+            "number"
+          ]
         },
         "name": {
           "type": "string"
@@ -272,7 +281,10 @@
           "$ref": "#/definitions/AwsTags"
         },
         "timeout": {
-          "type": ["string", "number"]
+          "type": [
+            "string",
+            "number"
+          ]
         },
         "tracing": {
           "type": "string"
@@ -406,7 +418,10 @@
         },
         "maxPreviousDeploymentArtifacts": {
           "description": "On deployment, serverless prunes artifacts older than this limit (default: 5)",
-          "type": ["string", "number"]
+          "type": [
+            "string",
+            "number"
+          ]
         },
         "name": {
           "description": "Name of an existing bucket to use (default: created by serverless)",
@@ -592,8 +607,16 @@
       },
       "type": "object",
       "anyOf": [
-        { "required": ["pattern"] },
-        { "required": ["schedule"] }
+        {
+          "required": [
+            "pattern"
+          ]
+        },
+        {
+          "required": [
+            "schedule"
+          ]
+        }
       ]
     },
     "AwsFunctions": {
@@ -710,7 +733,9 @@
           "title": "AwsHttpIamAuthorizerShort",
           "description": "AWS_IAM based authorizer, https://www.serverless.com/framework/docs/providers/aws/events/apigateway#http-endpoints-with-aws_iam-authorizers",
           "type": "string",
-          "enum": ["aws_iam"]
+          "enum": [
+            "aws_iam"
+          ]
         },
         {
           "title": "AwsHttpIamAuthorizer",
@@ -719,7 +744,9 @@
           "properties": {
             "type": {
               "type": "string",
-              "enum": ["aws_iam"]
+              "enum": [
+                "aws_iam"
+              ]
             }
           },
           "required": [
@@ -800,7 +827,12 @@
             },
             "type": {
               "type": "string",
-              "enum": ["request", "token", "REQUEST", "TOKEN"],
+              "enum": [
+                "request",
+                "token",
+                "REQUEST",
+                "TOKEN"
+              ],
               "default": "token"
             }
           },
@@ -816,7 +848,9 @@
           "properties": {
             "type": {
               "type": "string",
-              "enum": ["CUSTOM"]
+              "enum": [
+                "CUSTOM"
+              ]
             },
             "authorizerId": {
               "type": "string",
@@ -1068,7 +1102,11 @@
           "type": "string"
         },
         "endpointType": {
-          "enum": ["EDGE", "PRIVATE", "REGIONAL"],
+          "enum": [
+            "EDGE",
+            "PRIVATE",
+            "REGIONAL"
+          ],
           "type": "string"
         },
         "environment": {
@@ -1093,7 +1131,10 @@
           "type": "array"
         },
         "logRetentionInDays": {
-          "type": ["string", "number"]
+          "type": [
+            "string",
+            "number"
+          ]
         },
         "logs": {
           "$ref": "#/definitions/AwsLogs"
@@ -1110,10 +1151,15 @@
               "maximum": 10240
             }
           ],
-          "type": ["string", "number"]
+          "type": [
+            "string",
+            "number"
+          ]
         },
         "name": {
-          "enum": ["aws"],
+          "enum": [
+            "aws"
+          ],
           "type": "string"
         },
         "notificationArns": {
@@ -1129,7 +1175,10 @@
           "$ref": "components/common.json#/AwsRegion"
         },
         "reservedConcurrency": {
-          "type": ["string", "number"]
+          "type": [
+            "string",
+            "number"
+          ]
         },
         "resourcePolicy": {
           "items": {
@@ -1174,7 +1223,10 @@
           "$ref": "#/definitions/AwsTags"
         },
         "timeout": {
-          "type": ["string", "number"]
+          "type": [
+            "string",
+            "number"
+          ]
         },
         "tracing": {
           "$ref": "#/definitions/AwsTracing"
@@ -1204,7 +1256,10 @@
         "deploymentMethod": {
           "description": "Method used for CloudFormation deployments: 'changesets' or 'direct' (default: changesets). See https://www.serverless.com/framework/docs/providers/aws/guide/deploying#deployment-method",
           "type": "string",
-          "enum": ["direct", "changesets"]
+          "enum": [
+            "direct",
+            "changesets"
+          ]
         },
         "disableRollback": {
           "type": "boolean",
@@ -1217,15 +1272,23 @@
           "$ref": "components/lambda.json#/AwsLambdaRuntimeManagement"
         }
       },
-      "required": ["name"]
+      "required": [
+        "name"
+      ]
     },
     "AwsQuota": {
       "properties": {
         "limit": {
-          "type": ["string", "number"]
+          "type": [
+            "string",
+            "number"
+          ]
         },
         "offset": {
-          "type": ["string", "number"]
+          "type": [
+            "string",
+            "number"
+          ]
         },
         "period": {
           "type": "string"
@@ -1257,7 +1320,10 @@
           "type": "object"
         },
         "Effect": {
-          "enum": ["Allow", "Deny"],
+          "enum": [
+            "Allow",
+            "Deny"
+          ],
           "type": "string"
         },
         "Principal": {
@@ -1307,7 +1373,14 @@
               "$ref": "components/outputs.json#/AwsOutputs"
             },
             "Resources": {
-              "$ref": "resources/resources.schema.json#/properties/Resources"
+              "oneOf": [
+                {
+                  "$ref": "resources/resources.schema.json#/properties/Resources"
+                },
+                {
+                  "$ref": "https://raw.githubusercontent.com/awslabs/goformation/master/schema/cloudformation.schema.json#/properties/Resources"
+                }
+              ]
             },
             "Mappings": {
               "description": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/mappings-section-structure.html",
@@ -1398,7 +1471,10 @@
     "AwsRollbackConfiguration": {
       "properties": {
         "MonitoringTimeInMinutes": {
-          "type": ["string", "number"]
+          "type": [
+            "string",
+            "number"
+          ]
         },
         "RollbackTriggers": {
           "items": {
@@ -1492,13 +1568,19 @@
           "$ref": "components/cf.functions.json#/Aws_CF_Function"
         },
         "batchSize": {
-          "type": ["string", "number"]
+          "type": [
+            "string",
+            "number"
+          ]
         },
         "enabled": {
           "type": "boolean"
         },
         "startingPosition": {
-          "type": ["string", "number"]
+          "type": [
+            "string",
+            "number"
+          ]
         }
       },
       "type": "object"
@@ -1512,10 +1594,16 @@
     "AwsThrottle": {
       "properties": {
         "burstLimit": {
-          "type": ["string", "number"]
+          "type": [
+            "string",
+            "number"
+          ]
         },
         "rateLimit": {
-          "type": ["string", "number"]
+          "type": [
+            "string",
+            "number"
+          ]
         }
       },
       "type": "object"
@@ -1558,7 +1646,10 @@
         }
       },
       "type": "object",
-      "required": ["securityGroupIds", "subnetIds"]
+      "required": [
+        "securityGroupIds",
+        "subnetIds"
+      ]
     },
     "AwsWebsocket": {
       "properties": {
@@ -1595,7 +1686,10 @@
       "properties": {
         "level": {
           "type": "string",
-          "enum": ["INFO", "ERROR"]
+          "enum": [
+            "INFO",
+            "ERROR"
+          ]
         },
         "format": {
           "type": "string",
@@ -1699,5 +1793,8 @@
     }
   },
   "type": "object",
-  "required": ["provider", "service"]
+  "required": [
+    "provider",
+    "service"
+  ]
 }

--- a/serverless/reference.json
+++ b/serverless/reference.json
@@ -2,10 +2,7 @@
   "$schema": "https://json-schema.org/draft-07/schema#",
   "title": "ServerlessFrameworkConfiguration",
   "description": "Schema for serverless framework configuration files",
-  "fileMatch": [
-    "serverless.yml",
-    "serverless.yaml"
-  ],
+  "fileMatch": ["serverless.yml", "serverless.yaml"],
   "definitions": {
     "Transform": {
       "type": "object",
@@ -60,10 +57,7 @@
       "properties": {
         "apiKeySourceType": {
           "type": "string",
-          "enum": [
-            "HEADER",
-            "AUTHORIZER"
-          ]
+          "enum": ["HEADER", "AUTHORIZER"]
         },
         "binaryMediaTypes": {
           "description": "Optional binary media types the API might return",
@@ -229,10 +223,7 @@
           "type": "array"
         },
         "memorySize": {
-          "type": [
-            "string",
-            "number"
-          ]
+          "type": ["string", "number"]
         },
         "name": {
           "type": "string"
@@ -281,10 +272,7 @@
           "$ref": "#/definitions/AwsTags"
         },
         "timeout": {
-          "type": [
-            "string",
-            "number"
-          ]
+          "type": ["string", "number"]
         },
         "tracing": {
           "type": "string"
@@ -418,10 +406,7 @@
         },
         "maxPreviousDeploymentArtifacts": {
           "description": "On deployment, serverless prunes artifacts older than this limit (default: 5)",
-          "type": [
-            "string",
-            "number"
-          ]
+          "type": ["string", "number"]
         },
         "name": {
           "description": "Name of an existing bucket to use (default: created by serverless)",
@@ -607,16 +592,8 @@
       },
       "type": "object",
       "anyOf": [
-        {
-          "required": [
-            "pattern"
-          ]
-        },
-        {
-          "required": [
-            "schedule"
-          ]
-        }
+        { "required": ["pattern"] },
+        { "required": ["schedule"] }
       ]
     },
     "AwsFunctions": {
@@ -733,9 +710,7 @@
           "title": "AwsHttpIamAuthorizerShort",
           "description": "AWS_IAM based authorizer, https://www.serverless.com/framework/docs/providers/aws/events/apigateway#http-endpoints-with-aws_iam-authorizers",
           "type": "string",
-          "enum": [
-            "aws_iam"
-          ]
+          "enum": ["aws_iam"]
         },
         {
           "title": "AwsHttpIamAuthorizer",
@@ -744,9 +719,7 @@
           "properties": {
             "type": {
               "type": "string",
-              "enum": [
-                "aws_iam"
-              ]
+              "enum": ["aws_iam"]
             }
           },
           "required": [
@@ -827,12 +800,7 @@
             },
             "type": {
               "type": "string",
-              "enum": [
-                "request",
-                "token",
-                "REQUEST",
-                "TOKEN"
-              ],
+              "enum": ["request", "token", "REQUEST", "TOKEN"],
               "default": "token"
             }
           },
@@ -848,9 +816,7 @@
           "properties": {
             "type": {
               "type": "string",
-              "enum": [
-                "CUSTOM"
-              ]
+              "enum": ["CUSTOM"]
             },
             "authorizerId": {
               "type": "string",
@@ -1102,11 +1068,7 @@
           "type": "string"
         },
         "endpointType": {
-          "enum": [
-            "EDGE",
-            "PRIVATE",
-            "REGIONAL"
-          ],
+          "enum": ["EDGE", "PRIVATE", "REGIONAL"],
           "type": "string"
         },
         "environment": {
@@ -1131,10 +1093,7 @@
           "type": "array"
         },
         "logRetentionInDays": {
-          "type": [
-            "string",
-            "number"
-          ]
+          "type": ["string", "number"]
         },
         "logs": {
           "$ref": "#/definitions/AwsLogs"
@@ -1151,15 +1110,10 @@
               "maximum": 10240
             }
           ],
-          "type": [
-            "string",
-            "number"
-          ]
+          "type": ["string", "number"]
         },
         "name": {
-          "enum": [
-            "aws"
-          ],
+          "enum": ["aws"],
           "type": "string"
         },
         "notificationArns": {
@@ -1175,10 +1129,7 @@
           "$ref": "components/common.json#/AwsRegion"
         },
         "reservedConcurrency": {
-          "type": [
-            "string",
-            "number"
-          ]
+          "type": ["string", "number"]
         },
         "resourcePolicy": {
           "items": {
@@ -1223,10 +1174,7 @@
           "$ref": "#/definitions/AwsTags"
         },
         "timeout": {
-          "type": [
-            "string",
-            "number"
-          ]
+          "type": ["string", "number"]
         },
         "tracing": {
           "$ref": "#/definitions/AwsTracing"
@@ -1256,10 +1204,7 @@
         "deploymentMethod": {
           "description": "Method used for CloudFormation deployments: 'changesets' or 'direct' (default: changesets). See https://www.serverless.com/framework/docs/providers/aws/guide/deploying#deployment-method",
           "type": "string",
-          "enum": [
-            "direct",
-            "changesets"
-          ]
+          "enum": ["direct", "changesets"]
         },
         "disableRollback": {
           "type": "boolean",
@@ -1272,23 +1217,15 @@
           "$ref": "components/lambda.json#/AwsLambdaRuntimeManagement"
         }
       },
-      "required": [
-        "name"
-      ]
+      "required": ["name"]
     },
     "AwsQuota": {
       "properties": {
         "limit": {
-          "type": [
-            "string",
-            "number"
-          ]
+          "type": ["string", "number"]
         },
         "offset": {
-          "type": [
-            "string",
-            "number"
-          ]
+          "type": ["string", "number"]
         },
         "period": {
           "type": "string"
@@ -1320,10 +1257,7 @@
           "type": "object"
         },
         "Effect": {
-          "enum": [
-            "Allow",
-            "Deny"
-          ],
+          "enum": ["Allow", "Deny"],
           "type": "string"
         },
         "Principal": {
@@ -1471,10 +1405,7 @@
     "AwsRollbackConfiguration": {
       "properties": {
         "MonitoringTimeInMinutes": {
-          "type": [
-            "string",
-            "number"
-          ]
+          "type": ["string", "number"]
         },
         "RollbackTriggers": {
           "items": {
@@ -1568,19 +1499,13 @@
           "$ref": "components/cf.functions.json#/Aws_CF_Function"
         },
         "batchSize": {
-          "type": [
-            "string",
-            "number"
-          ]
+          "type": ["string", "number"]
         },
         "enabled": {
           "type": "boolean"
         },
         "startingPosition": {
-          "type": [
-            "string",
-            "number"
-          ]
+          "type": ["string", "number"]
         }
       },
       "type": "object"
@@ -1594,16 +1519,10 @@
     "AwsThrottle": {
       "properties": {
         "burstLimit": {
-          "type": [
-            "string",
-            "number"
-          ]
+          "type": ["string", "number"]
         },
         "rateLimit": {
-          "type": [
-            "string",
-            "number"
-          ]
+          "type": ["string", "number"]
         }
       },
       "type": "object"
@@ -1646,10 +1565,7 @@
         }
       },
       "type": "object",
-      "required": [
-        "securityGroupIds",
-        "subnetIds"
-      ]
+      "required": ["securityGroupIds", "subnetIds"]
     },
     "AwsWebsocket": {
       "properties": {
@@ -1686,10 +1602,7 @@
       "properties": {
         "level": {
           "type": "string",
-          "enum": [
-            "INFO",
-            "ERROR"
-          ]
+          "enum": ["INFO", "ERROR"]
         },
         "format": {
           "type": "string",
@@ -1793,8 +1706,5 @@
     }
   },
   "type": "object",
-  "required": [
-    "provider",
-    "service"
-  ]
+  "required": ["provider", "service"]
 }


### PR DESCRIPTION
## Overview

- Description: My intention is to offer a schema that has the official resources available in Amazon Web Services Cloud Formation
- Schema update type: modification
- Services affected: Serverless Framework > Resources > Add official resources

## How was this tested?
It has been tested in VsCode using YAML as extension and the organization repository (arcaelas/json-schema) as source schema.

[Describe what steps were taken to ensure this schema change is correct & necessary]
Install YAML in VsCode and set the "yaml.schemas" property in the VSCode configuration file:
```json
{
 "yaml.schemas":{
  "https://github.com/arcaelas/json-schema/raw/master/serverless/reference.json": "serverless.yml"
 }
}
```
