### PR TITLE
fix: DynamoDB Table AttributeName max length to 255 in cloudformation-modified

### DIFF
--- a/serverless/resources/cloudformation-modified/aws-dynamodb-table.json
+++ b/serverless/resources/cloudformation-modified/aws-dynamodb-table.json
@@ -401,7 +401,7 @@
             {
               "type": "string",
               "minLength": 1,
-              "maxLength": 1
+              "maxLength": 255
             },
             {
               "$ref": "../../components/cf.functions.json#/Aws_CF_FunctionString"


### PR DESCRIPTION
## Overview

- Description: Fixes AttributeName max length in the directory serverless/resources/cloudformation-modified (missed in #152)
- Schema update type: [create, modification, extend, remove]
- Services affected: 

## References

#152
- [documentation/forum thread links]

## How was this tested?

[Describe what steps were taken to ensure this schema change is correct & necessary]
