### PR TITLE
Update lambda.json

### DIFF
--- a/serverless/components/lambda.json
+++ b/serverless/components/lambda.json
@@ -11,6 +11,7 @@
       "nodejs16.x",
       "nodejs14.x",
       "nodejs12.x",
+      "python3.10",
       "python3.9",
       "python3.8",
       "python3.7",


### PR DESCRIPTION
python3.10 now supported by AWS Lambda

## Overview

- Description: python3.10 now supported as a lambda runtime
- Schema update type: extend
- Services affected: lambda

## References

- [Lambda runtimes](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html)

## How was this tested?

Tested locally on multiple serverless.yml files
