### PR TITLE
Declare Map.ItemProcessor.ProcessorConfig's Mode and Execution as non-required

### DIFF
--- a/serverless/plugin/step_functions.json
+++ b/serverless/plugin/step_functions.json
@@ -1547,7 +1547,28 @@
                     "enum": ["STANDARD", "EXPRESS"],
                     "default": "STANDARD"
                   }
-                }
+                },
+                "anyOf": [
+                  {
+                    "properties": {
+                       "Mode": { "const": "DISTRIBUTED" }
+                    },
+                    "required": ["Mode"]
+                  },
+                  {
+                    "properties": {
+                    	 "Mode": { "const": "INLINE" },
+                    },
+	                  "required": ["Mode"],
+                    "dependencies": {
+					            "Mode": {
+                        "not": {
+                          "required": ["ExecutionType"]
+                        }
+                      }
+                    }
+                  }
+                ]
               }
             }
           }

--- a/serverless/plugin/step_functions.json
+++ b/serverless/plugin/step_functions.json
@@ -1547,11 +1547,7 @@
                     "enum": ["STANDARD", "EXPRESS"],
                     "default": "STANDARD"
                   }
-                },
-                "required": [
-                  "Mode",
-                  "ExecutionType"
-                ]
+                }
               }
             }
           }

--- a/serverless/plugin/step_functions.json
+++ b/serverless/plugin/step_functions.json
@@ -1532,15 +1532,14 @@
             "$ref": "#/AwsStateMachineDefinition"
           },
           {
-            "type": "object",
+           "type": "object",
             "properties": {
               "ProcessorConfig": {
                 "type": ["object"],
                 "properties": {
                   "Mode": {
                     "type": "string",
-                    "enum": ["DISTRIBUTED", "INLINE"],
-                    "default": "INLINE"
+                    "enum": ["DISTRIBUTED", "INLINE"]
                   },
                   "ExecutionType": {
                     "type": "string",
@@ -1551,21 +1550,17 @@
                 "anyOf": [
                   {
                     "properties": {
-                       "Mode": { "const": "DISTRIBUTED" }
+                      "Mode": { "const": "DISTRIBUTED" }
                     },
-                    "required": ["Mode"]
+                    "required": ["Mode", "ExecutionType"]
                   },
                   {
                     "properties": {
-                    	 "Mode": { "const": "INLINE" },
+                    	"Mode": { "const": "INLINE" },
                     },
-	                  "required": ["Mode"],
+                    "required": ["Mode"],
                     "dependencies": {
-					            "Mode": {
-                        "not": {
-                          "required": ["ExecutionType"]
-                        }
-                      }
+			"Mode": { "not": { "required": ["ExecutionType"] } }
                     }
                   }
                 ]


### PR DESCRIPTION
## Overview

- Description: `Mode` and `Execution` of `Map.ItemProcessor.ProcessorConfig` are optional. Furthermore, If `Mode` is `INLINE`, `ExecutionType` should not be specified and doing so throws an error; if `Mode` is `DISTRIBUTED`, `ExecutionType` needs to be specified explicitly as per documentation.
- Schema update type: Remove the requirement for the `Mode` and `ExecutionType`
- Services affected: serverless-step-functions plugin (step-functions)

## References

- [Map schema documentation](https://docs.aws.amazon.com/step-functions/latest/dg/concepts-asl-use-map-state-distributed.html)
- [Map schema documentation examples](https://docs.aws.amazon.com/step-functions/latest/dg/concepts-asl-use-map-state-inline.html) *Note: One of the examples only specifies `Mode: INLINE`, but the current schema invalidates that example.*

## How was this tested?

To reproduce, add the following state to a state machine:
```yaml
Validate All:
  Type: Map
  InputPath: "$.detail"
  ItemProcessor:
    ProcessorConfig:
      Mode: INLINE
    StartAt: Validate
    States:
      Validate:
        Type: Task
        Resource: arn:aws:states:::lambda:invoke
        OutputPath: "$.Payload"
        Parameters:
          FunctionName: arn:aws:lambda:us-east-2:123456789012:function:ship-val:$LATEST
        End: true
  End: true
  ResultPath: "$.detail.shipped"
  ItemsPath: "$.shipped"
```

Removing `ProcessorConfig`, or adding `ExecutionType` within it fixes validation, but throws an error during stack deployment. Having just the `ExecutionType` results in an identical validation error.