### PR TITLE
Add Python 3.10 runtime

### DIFF
--- a/serverless/components/layers.json
+++ b/serverless/components/layers.json
@@ -11,6 +11,7 @@
       "nodejs16.x",
       "nodejs14.x",
       "nodejs12.x",
+      "python3.10",
       "python3.9",
       "python3.8",
       "python3.7",

--- a/serverless/plugin/python_requirements.json
+++ b/serverless/plugin/python_requirements.json
@@ -86,6 +86,7 @@
                 "items": {
                   "type": "string",
                   "enum": [
+                    "python3.10",
                     "python3.9",
                     "python3.8",
                     "python3.7",


### PR DESCRIPTION
## Overview

- Description: Adding the missing Python 3.10 runtime
- Schema update type: modification
- Services affected: serverless layers, serverless python requirements

## References

- [Lambda Runtimes](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html)

## How was this tested?

Tested locally on multiple projects serverless.
