### PR TITLE
Update reference.json

### DIFF
--- a/serverless/reference.json
+++ b/serverless/reference.json
@@ -520,7 +520,14 @@
           "$ref": "components/events.json#/AwsSns"
         },
         "sqs": {
-          "$ref": "components/events.json#/AwsSqs"
+          "anyOf": [
+            {
+              "$ref": "components/events.json#/AwsSqs"
+            },
+            {
+              "type": "string"
+            }
+          ]
         },
         "stream": {
           "$ref": "#/definitions/AwsStream"


### PR DESCRIPTION
Add string type to `sqs` event

## Overview

- Description: Based on [this documentation](https://www.serverless.com/framework/docs/providers/aws/events/sqs), passing the resource ARN as a string directly to the `sqs` property is supported
- Schema update type: extend
- Services affected: SQS

## References

- [documentation/forum thread links]

## How was this tested?

[Describe what steps were taken to ensure this schema change is correct & necessary]
