### PR TITLE
fix: update http event definition for step functions

### DIFF
--- a/serverless/plugin/step_functions.json
+++ b/serverless/plugin/step_functions.json
@@ -106,17 +106,60 @@
       }
     }
   },
+  "AwsStateMachineHttpRequestParametersValidation": {
+    "properties": {
+      "headers": {
+        "additionalProperties": {
+          "type": "boolean"
+        },
+        "type": "object"
+      },
+      "paths": {
+        "additionalProperties": {
+          "type": "boolean"
+        },
+        "type": "object"
+      },
+      "querystrings": {
+        "additionalProperties": {
+          "type": "boolean"
+        },
+        "type": "object"
+      }
+    },
+    "type": "object"
+  },
+  "AwsStateMachineHttpRequestValidation": {
+    "type": "object",
+    "properties": {
+      "parameters": {
+        "$ref": "#/definitions/AwsStateMachineHttpRequestParametersValidation"
+      },
+      "schemas": {
+        "additionalProperties": {
+          "type": "string"
+        },
+        "type": "object"
+      }
+    }
+  },
   "AwsStateMachineHttpEvent": {
     "type": "object",
     "properties": {
       "path": {
         "type": "string"
+      },
+      "method": {
+        "type": "string"
+      },
+      "private": {
+        "type": "boolean"
+      },
+      "request": {
+        "$ref": "#/AwsStateMachineHttpRequestValidation"
       }
     },
-    "required": [
-      "path"
-    ],
-    "additionalProperties": false
+    "required": ["path"]
   },
   "AwsStateMachineEventBridgeEvent": {
     "type": "object",
@@ -155,15 +198,11 @@
             ]
           }
         },
-        "required": [
-          "source"
-        ],
+        "required": ["source"],
         "additionalProperties": false
       }
     },
-    "required": [
-      "event"
-    ],
+    "required": ["event"],
     "additionalProperties": false
   },
   "AwsStateMachineDefinition": {
@@ -1532,7 +1571,7 @@
             "$ref": "#/AwsStateMachineDefinition"
           },
           {
-           "type": "object",
+            "type": "object",
             "properties": {
               "ProcessorConfig": {
                 "type": ["object"],
@@ -1556,11 +1595,11 @@
                   },
                   {
                     "properties": {
-                    	"Mode": { "const": "INLINE" }
+                      "Mode": { "const": "INLINE" }
                     },
                     "required": ["Mode"],
                     "dependencies": {
-			"Mode": { "not": { "required": ["ExecutionType"] } }
+                      "Mode": { "not": { "required": ["ExecutionType"] } }
                     }
                   }
                 ]


### PR DESCRIPTION
## Overview

- Description: http events have other properties supported by the plugin others than just path
- Schema update type: extend `AwsStateMachineHttpEvent` definition
- Services affected: serverless-step-functions plugin (step-functions)

## References

- [documentation/forum thread links]

## How was this tested?

[Describe what steps were taken to ensure this schema change is correct & necessary]
