### PR TITLE
Add Java 17, Ruby 3.2 and Python 3.11 runtimes to the schema

### DIFF
--- a/serverless/components/lambda.json
+++ b/serverless/components/lambda.json
@@ -11,6 +11,7 @@
       "nodejs16.x",
       "nodejs14.x",
       "nodejs12.x",
+      "python3.11",
       "python3.10",
       "python3.9",
       "python3.8",

--- a/serverless/components/lambda.json
+++ b/serverless/components/lambda.json
@@ -18,6 +18,7 @@
       "python3.7",
       "python3.6",
       "ruby2.7",
+      "java17",
       "java11",
       "java8.al2",
       "java8",

--- a/serverless/components/lambda.json
+++ b/serverless/components/lambda.json
@@ -17,6 +17,7 @@
       "python3.8",
       "python3.7",
       "python3.6",
+      "ruby3.2",
       "ruby2.7",
       "java17",
       "java11",

--- a/serverless/components/layers.json
+++ b/serverless/components/layers.json
@@ -11,6 +11,7 @@
       "nodejs16.x",
       "nodejs14.x",
       "nodejs12.x",
+      "python3.11",
       "python3.10",
       "python3.9",
       "python3.8",

--- a/serverless/components/layers.json
+++ b/serverless/components/layers.json
@@ -18,6 +18,7 @@
       "python3.7",
       "python3.6",
       "ruby2.7",
+      "java17",
       "java11",
       "java8.al2",
       "java8",

--- a/serverless/components/layers.json
+++ b/serverless/components/layers.json
@@ -17,6 +17,7 @@
       "python3.8",
       "python3.7",
       "python3.6",
+      "ruby3.2",
       "ruby2.7",
       "java17",
       "java11",

--- a/serverless/plugin/python_requirements.json
+++ b/serverless/plugin/python_requirements.json
@@ -86,6 +86,7 @@
                 "items": {
                   "type": "string",
                   "enum": [
+                    "python3.11",
                     "python3.10",
                     "python3.9",
                     "python3.8",


### PR DESCRIPTION
## Overview

- Description: Add new runtimes to the JSON schema validation. 

- Schema update type: extend
- Services affected: 
    - Lambda Runtimes
    - Lambda Layers
    - Serverless Python Requirements Plugin
## References

Taken from: https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html
Also confirmed they all have been added to serverless already, with Python 3.11 being the latest addition [as of yesterday](https://github.com/serverless/serverless/releases/tag/v3.34.0).

## How was this tested?

Not at all, but they are simple additions.
