### PR TITLE
Add NodeJS 20 and Java 21 runtimes

### DIFF
--- a/serverless/components/lambda.json
+++ b/serverless/components/lambda.json
@@ -7,6 +7,7 @@
   "AwsRuntime": {
     "type": "string",
     "enum": [
+      "nodejs20.x",
       "nodejs18.x",
       "nodejs16.x",
       "nodejs14.x",
@@ -19,6 +20,7 @@
       "python3.6",
       "ruby3.2",
       "ruby2.7",
+      "java21",
       "java17",
       "java11",
       "java8.al2",

--- a/serverless/components/layers.json
+++ b/serverless/components/layers.json
@@ -7,6 +7,7 @@
   "LayerAwsCompatibleRuntime": {
     "type": "string",
     "enum": [
+      "nodejs20.x",
       "nodejs18.x",
       "nodejs16.x",
       "nodejs14.x",
@@ -19,6 +20,7 @@
       "python3.6",
       "ruby3.2",
       "ruby2.7",
+      "java21",
       "java17",
       "java11",
       "java8.al2",


### PR DESCRIPTION
## Overview

- Description: Add new runtimes to the JSON schema validation.
- Schema update type: extend
- Services affected: Lambda Runtimes, Lambda Layers, Serverless Plugin

## References

- Please see https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html

## How was this tested?
- None
