### PR TITLE
new aws region value added

### DIFF
--- a/serverless/components/common.json
+++ b/serverless/components/common.json
@@ -36,6 +36,7 @@
       "ap-northeast-2",
       "ap-northeast-3",
       "ap-south-1",
+      "ap-south-2",
       "ap-southeast-1",
       "ap-southeast-2",
       "ap-southeast-3",


### PR DESCRIPTION
new aws region

configuration validation is failing because missing value of a new aws region named **Asia Pacific (Hyderabad)**
