### PR TITLE
feat(167): aws lambda now supports python3.12 runtime.

### DIFF
--- a/serverless/components/lambda.json
+++ b/serverless/components/lambda.json
@@ -12,6 +12,7 @@
       "nodejs16.x",
       "nodejs14.x",
       "nodejs12.x",
+      "python3.12",
       "python3.11",
       "python3.10",
       "python3.9",

--- a/serverless/components/layers.json
+++ b/serverless/components/layers.json
@@ -12,6 +12,7 @@
       "nodejs16.x",
       "nodejs14.x",
       "nodejs12.x",
+      "python3.12",
       "python3.11",
       "python3.10",
       "python3.9",

--- a/serverless/plugin/python_requirements.json
+++ b/serverless/plugin/python_requirements.json
@@ -86,6 +86,7 @@
                 "items": {
                   "type": "string",
                   "enum": [
+                    "python3.12",
                     "python3.11",
                     "python3.10",
                     "python3.9",


### PR DESCRIPTION
Close #167 