### PR TITLE
Add provided.al2023 as supported runtime

### DIFF
--- a/serverless/components/lambda.json
+++ b/serverless/components/lambda.json
@@ -30,6 +30,7 @@
       "dotnet6",
       "dotnetcore3.1",
       "dotnet5.0",
+      "provided.al2023",
       "provided.al2",
       "provided"
     ],


### PR DESCRIPTION
## Overview

- Description: Add provided.al2023 runtime
- Schema update type: extend
- Services affected: Lambda

## References

- Serverless issue: https://github.com/serverless/serverless/issues/12250
- Serverless release: https://github.com/serverless/serverless/releases/tag/v3.38.0