### PR TITLE
Update event source type to array in Step Functions schema

### DIFF
--- a/serverless/plugin/step_functions.json
+++ b/serverless/plugin/step_functions.json
@@ -136,7 +136,10 @@
         "description": "EventBridge event pattern see:- https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-events.html",
         "properties": {
           "source": {
-            "type": "string"
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
           },
           "detail": {
             "type": "object"


### PR DESCRIPTION
## Overview

- Description: event source pattern must be array of string, but schema indicates just string
- Schema update type: modification
- Services affected: 

## error-log
```
Resource handler returned message: "Event pattern is not valid. Reason: "source" must be an object or an array at [Source: (String)"{"detail-type":["Object Created"],"source":"aws.s3","detail":{"bucket":"sabi-test-bucket","object":{"key":[{"prefix":"reach-query"},{"suffix":".json"}]}}}"; line: 1, column: 45] (Service: EventBridge, Status Code: 400, Request ID: d29dbadf-407c-48f0-822a-927d5fcc8b01)" (RequestToken: 03c62818-7f8e-71a5-72a9-c1077f4531c3, HandlerErrorCode: InvalidRequest)
```

## References

- https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-event-patterns.html#eb-filtering-match-values

## How was this tested?

[Describe what steps were taken to ensure this schema change is correct & necessary]
