### PR TITLE
Added support for strings to `securityGroupIds` and `subnetIds`

### DIFF
--- a/serverless/reference.json
+++ b/serverless/reference.json
@@ -1553,13 +1553,27 @@
       "properties": {
         "securityGroupIds": {
           "items": {
-            "$ref": "components/cf.functions.json#/Aws_CF_Function"
+            "anyOf": [
+              {
+                "$ref": "components/cf.functions.json#/Aws_CF_Function"
+              },
+              {
+                "type":"string"
+              }
+            ]
           },
           "type": "array"
         },
         "subnetIds": {
           "items": {
-            "$ref": "components/cf.functions.json#/Aws_CF_Function"
+            "anyOf": [
+              {
+                "$ref": "components/cf.functions.json#/Aws_CF_Function"
+              },
+              {
+                "type":"string"
+              }
+            ]
           },
           "type": "array"
         }


### PR DESCRIPTION
## Overview

- Description: Allow string values for `securityGroupIds` and `subnetIds`
- Schema update type: extend
- Services affected: Lambda / VPC

## References

- [Serverless Functions VPC Configuration](https://www.serverless.com/framework/docs/providers/aws/guide/functions#vpc-configuration)

## How was this tested?

Verified locally using VSCode YAML extension on serverless.yml file.
