### PR TITLE
Lambda authorizer `name` is no longer required if `arn` is provided

### DIFF
--- a/serverless/reference.json
+++ b/serverless/reference.json
@@ -811,8 +811,17 @@
               "default": "token"
             }
           },
-          "required": [
-            "name"
+          "oneOf": [
+            {
+              "required": [
+                "arn"
+              ]
+            },
+            {
+              "required": [
+                "name"
+              ]
+            }
           ],
           "additionalProperties": false
         },


### PR DESCRIPTION
## Overview

- Description: Custom authorizer `name` is no longer required when `arn` value is provided.
- Schema update type: extend
- Services affected: APIGateway

## References

- [Serverless Events APIGateway Custom Authorizers](https://www.serverless.com/framework/docs/providers/aws/events/apigateway#http-endpoints-with-custom-authorizers)

## How was this tested?

Verified locally using VSCode YAML extension on serverless.yml file.
