### PR TITLE
Add dotnet8 to lambda runtime

### DIFF
--- a/serverless/components/lambda.json
+++ b/serverless/components/lambda.json
@@ -28,6 +28,7 @@
       "java8",
       "go1.x",
       "dotnet6",
+      "dotnet8",
       "dotnetcore3.1",
       "dotnet5.0",
       "provided.al2023",


### PR DESCRIPTION
## Overview

Description: Add .NET8 as a new runtime to the JSON schema validation.
Schema update type: extend
Services affected: Lambda Runtimes
## References
https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html

## How was this tested?
Null
