### PR TITLE
Include support for nodejs22.x

### DIFF
--- a/serverless/components/lambda.json
+++ b/serverless/components/lambda.json
@@ -7,6 +7,7 @@
   "AwsRuntime": {
     "type": "string",
     "enum": [
+      "nodejs22.x",
       "nodejs20.x",
       "nodejs18.x",
       "nodejs16.x",


### PR DESCRIPTION
Include new AWS runtime per https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html

## Overview

- Description: AWS has added support for nodejs 22
- Schema update type: extend
- Services affected: AWS Lambda

## References

- https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html

## How was this tested?

I'm not sure how to test this.