### PR TITLE
fix(schema): update Aurora Serverless v2 MinCapacity constraints

### DIFF
--- a/serverless/resources/cloudformation-modified/aws-rds-dbcluster.json
+++ b/serverless/resources/cloudformation-modified/aws-rds-dbcluster.json
@@ -535,9 +535,9 @@
       "additionalProperties": false,
       "properties": {
         "MinCapacity": {
-          "description": "The minimum number of Aurora capacity units (ACUs) for a DB instance in an Aurora Serverless v2 cluster. You can specify ACU values in half-step increments, such as 8, 8.5, 9, and so on. The smallest value that you can use is 0.5.",
+          "description": "The minimum number of Aurora capacity units (ACUs) for a DB instance in an Aurora Serverless v2 cluster. You can specify ACU values in half-step increments, such as 8, 8.5, 9, and so on. For Aurora versions that support the Aurora Serverless v2 auto-pause feature, the smallest value that you can use is 0. For versions that don't support Aurora Serverless v2 auto-pause, the smallest value that you can use is 0.5.",
           "type": "number",
-          "minimum": 0.5,
+          "minimum": 0,
           "maximum": 128
         },
         "MaxCapacity": {

--- a/serverless/resources/cloudformation/aws-rds-dbcluster.json
+++ b/serverless/resources/cloudformation/aws-rds-dbcluster.json
@@ -314,9 +314,9 @@
       "additionalProperties" : false,
       "properties" : {
         "MinCapacity" : {
-          "description" : "The minimum number of Aurora capacity units (ACUs) for a DB instance in an Aurora Serverless v2 cluster. You can specify ACU values in half-step increments, such as 8, 8.5, 9, and so on. The smallest value that you can use is 0.5.",
+          "description" : "The minimum number of Aurora capacity units (ACUs) for a DB instance in an Aurora Serverless v2 cluster. You can specify ACU values in half-step increments, such as 8, 8.5, 9, and so on. For Aurora versions that support the Aurora Serverless v2 auto-pause feature, the smallest value that you can use is 0. For versions that don't support Aurora Serverless v2 auto-pause, the smallest value that you can use is 0.5.",
           "type" : "number",
-          "minimum" : 0.5,
+          "minimum" : 0,
           "maximum" : 128
         },
         "MaxCapacity" : {


### PR DESCRIPTION
## Overview

- Description: Update Aurora Serverless v2 MinCapacity constraints to support auto-pause feature. The current schema incorrectly sets the minimum ACU value to 0.5, which prevents users from configuring clusters with auto-pause capability (which requires a minimum of 0.0 ACUs).
- Schema update type: modification
- Services affected: AWS::RDS::DBCluster (Aurora Serverless v2)

## References

- [AWS::RDS::DBCluster ServerlessV2ScalingConfiguration](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-rds-dbcluster-serverlessv2scalingconfiguration.html)
- [Aurora Serverless v2 capacity range documentation](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/aurora-serverless-v2.setting-capacity.html)
- [Aurora Serverless v2 auto-pause feature](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/aurora-serverless-v2.auto-pause.html)
