### PR TITLE
Include support for nodejs24.x lambda runtime

### DIFF
--- a/serverless/components/lambda.json
+++ b/serverless/components/lambda.json
@@ -7,6 +7,7 @@
   "AwsRuntime": {
     "type": "string",
     "enum": [
+      "nodejs24.x",
       "nodejs22.x",
       "nodejs20.x",
       "nodejs18.x",

--- a/serverless/components/layers.json
+++ b/serverless/components/layers.json
@@ -7,6 +7,8 @@
   "LayerAwsCompatibleRuntime": {
     "type": "string",
     "enum": [
+      "nodejs24.x",
+      "nodejs22.x",
       "nodejs20.x",
       "nodejs18.x",
       "nodejs16.x",


### PR DESCRIPTION
## Overview

- Description: Updates runtimes to include nodejs24.x and match https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html
- Schema update type: modification
- Services affected: Serverless, AWS Lambda

## References

https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html

## How was this tested?

Not tested
