### PR TITLE
Add Ruby 3.3 and 3.4 support for AWS Lambda Runtimes & Layers

### DIFF
--- a/serverless/components/lambda.json
+++ b/serverless/components/lambda.json
@@ -21,6 +21,8 @@
       "python3.8",
       "python3.7",
       "python3.6",
+      "ruby3.4",      
+      "ruby3.3",
       "ruby3.2",
       "ruby2.7",
       "java21",

--- a/serverless/components/layers.json
+++ b/serverless/components/layers.json
@@ -21,6 +21,8 @@
       "python3.8",
       "python3.7",
       "python3.6",
+      "ruby3.4",      
+      "ruby3.3",
       "ruby3.2",
       "ruby2.7",
       "java21",


### PR DESCRIPTION
Updates the supported runtimes as per AWS Lambda current support policy - https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html
