### PR TITLE
Fix incorrect type ARN error

### DIFF
--- a/serverless/components/common.json
+++ b/serverless/components/common.json
@@ -18,6 +18,19 @@
     "type": "string",
     "pattern": "^arn:"
   },
+  "AwsArnReference": {
+    "oneOf": [
+      {
+        "$ref": "cf.functions.json#/FnRef"
+      },
+      {
+        "$ref": "cf.functions.json#/FnGetAtt"
+      },
+      {
+        "$ref": "#/AwsArnString"
+      }
+    ]
+  },
   "AwsRegion": {
     "type": "string",
     "enum": [

--- a/serverless/components/events.json
+++ b/serverless/components/events.json
@@ -96,7 +96,7 @@
         "pattern": "^[\\w-]+$"
       },
       "arn": {
-        "$ref": "common.json#/AwsArnString"
+        "$ref": "common.json#/AwsArnReference"
       },
       "filterPolicyScope": {
         "type": "string"
@@ -109,7 +109,7 @@
   "AwsSnsRedrivePolicy": {
     "properties": {
       "deadLetterTargetArn": {
-        "$ref": "common.json#/AwsArnString"
+        "$ref": "common.json#/AwsArnReference"
       },
       "deadLetterTargetImport": {
         "$ref": "#/AwsSnsDeadLetterTargetImport"
@@ -130,7 +130,7 @@
   "AwsSnsDeadLetterTargetImport": {
     "properties": {
       "arn": {
-        "type": "string"
+        "$ref": "common.json#/AwsArnReference"
       },
       "url": {
         "type": "string"
@@ -141,17 +141,7 @@
   "AwsSqs": {
     "properties": {
       "arn": {
-        "anyOf": [
-          {
-            "$ref": "cf.functions.json#/FnRef"
-          },
-          {
-            "$ref": "cf.functions.json#/FnGetAtt"
-          },
-          {
-            "$ref": "common.json#/AwsArnString"
-          }
-        ]
+        "$ref": "common.json#/AwsArnReference"
       },
       "batchSize": {
         "type": "number",
@@ -205,7 +195,7 @@
         "type": "object"
       },
       "listenerArn": {
-        "type": "string"
+        "$ref": "common.json#/AwsArnReference"
       },
       "priority": {
         "type": ["string", "number"]


### PR DESCRIPTION
## Overview

This fixes the `Incorrect type. Expected "string".` error and makes ARN types consistent.

<img width="454" alt="PixelSnap 2026-03-27 at 17 00 21@2x" src="https://github.com/user-attachments/assets/859df302-7277-497f-a405-4183ee7cac47" />

## How was this tested?

```
functions:
  example:
    events:
      - sns:
          arn: arn:aws:sns:eu-west-1:123456789012:example-topic
      - sns:
          arn:
            Ref: ExampleTopic
      - sns:
          arn:
            Fn::GetAtt:
              - ExampleTopic
              - TopicArn

resources:
  Resources:
    ExampleTopic:
      Type: AWS::SNS::Topic
      Properties:
        TopicName: example-topic
```