### PR TITLE
Fix matches multiple schemas error

### DIFF
--- a/serverless/components/cf.functions.json
+++ b/serverless/components/cf.functions.json
@@ -478,7 +478,9 @@
           }
         }
       }
-    }
+    },
+    "required": ["Fn::Transform"],
+    "additionalProperties": false
   },
   "FnAnd": {
     "type": "object",


### PR DESCRIPTION
## Overview

This fixes the `Matches multiple schemas when only one must validate` error by preventing `{ Ref: ... }` from also matching `FnTransform`.

<img width="180" alt="PixelSnap 2026-03-27 at 16 59 31@2x" src="https://github.com/user-attachments/assets/4b89d43c-303a-463a-bf83-27a1a4ec50f4" />

## How was this tested?

```
functions:
  example:
    layers:
      - Ref: ExampleLayer
```