### PR TITLE
Fix JSON reference for AwsStateMachineHttpRequestParameters

### DIFF
--- a/serverless/plugin/step_functions.json
+++ b/serverless/plugin/step_functions.json
@@ -133,7 +133,7 @@
     "type": "object",
     "properties": {
       "parameters": {
-        "$ref": "#/definitions/AwsStateMachineHttpRequestParametersValidation"
+        "$ref": "#/AwsStateMachineHttpRequestParametersValidation"
       },
       "schemas": {
         "additionalProperties": {


### PR DESCRIPTION
## Overview

- Description: IDE is throwing error as the reference path is broken.
- Schema update type: modification
- Services affected: 

## References

- https://github.com/lalcebo/json-schema/issues/186

## How was this tested?

Cloned schemas locally and updated the broken reference. It resolves fine now.
